### PR TITLE
Update core-lib and add new primitives needed support for SomSom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,20 @@ jobs:
           PYTHONPATH=$PYTHONPATH:.pypy ./som.sh -cp Smalltalk TestSuite/TestHarness.som
           PYTHONPATH=$PYTHONPATH:.pypy .pypy/rpython/bin/rpython --batch src/main-rpython.py
           ./som-${{ matrix.id }}-interp -cp Smalltalk TestSuite/TestHarness.som
+      
+      - name: SomSom Tests Basic
+        if: matrix.id == 'basic'
+        run: |
+          SOM_INTERP=AST ./som.sh -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives \
+            core-lib/SomSom/tests/SomSomTests.som
+          SOM_INTERP=BC  ./som.sh -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives \
+            core-lib/SomSom/tests/SomSomTests.som
+
+      - name: SomSom Tests Compiled
+        if: matrix.id != 'basic'
+        run: |
+          ./som-${{ matrix.id }}-interp -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives \
+            core-lib/SomSom/tests/SomSomTests.som
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,16 +64,8 @@ jobs:
           PYTHONPATH=$PYTHONPATH:.pypy ./som.sh -cp Smalltalk TestSuite/TestHarness.som
           PYTHONPATH=$PYTHONPATH:.pypy .pypy/rpython/bin/rpython --batch src/main-rpython.py
           ./som-${{ matrix.id }}-interp -cp Smalltalk TestSuite/TestHarness.som
-      
-      - name: SomSom Tests Basic
-        if: matrix.id == 'basic'
-        run: |
-          SOM_INTERP=AST ./som.sh -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives \
-            core-lib/SomSom/tests/SomSomTests.som
-          SOM_INTERP=BC  ./som.sh -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives \
-            core-lib/SomSom/tests/SomSomTests.som
 
-      - name: SomSom Tests Compiled
+      - name: SomSom Tests
         if: matrix.id != 'basic'
         run: |
           ./som-${{ matrix.id }}-interp -cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ bc_build_test_benchmark_job:
     - ./som-bc-jit -cp Smalltalk TestSuite/TestHarness.som
     
     # Run Benchmarks
-    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf RPySOM e:RPySOM-bc-jit e:RPySOM-bc-interp
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf all e:RPySOM-bc-jit e:RPySOM-bc-interp e:SomSom-bc-interp
     # - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf
 
 ast_build_test_benchmark_job:
@@ -57,5 +57,5 @@ ast_build_test_benchmark_job:
     - ./som-ast-jit -cp Smalltalk TestSuite/TestHarness.som
     
     # Run Benchmarks
-    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf RPySOM e:RPySOM-ast-jit e:RPySOM-ast-interp
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf all e:RPySOM-ast-jit e:RPySOM-ast-interp e:SomSom-ast-interp
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf

--- a/rebench.conf
+++ b/rebench.conf
@@ -93,6 +93,17 @@ benchmark_suites:
             - WhileLoop:    {extra_args: 9000,   warmup:   5,   iterations:  55}
             - Mandelbrot:   {extra_args: 1000,   warmup:  10,   iterations: 110}
 
+    micro-somsom:
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
+        iterations: 1
+        benchmarks:
+            - Loop:         {extra_args: 1}
+            - Queens:       {extra_args: 1}
+            - List:         {extra_args: 1}
+            - Recurse:      {extra_args: 1}
+            - Mandelbrot:   {extra_args: 3}
+
 executors:
     RPySOM-ast-interp:
         path: .
@@ -106,6 +117,16 @@ executors:
     RPySOM-bc-jit:
         path: .
         executable: som-bc-jit
+
+    SomSom-ast-interp:
+        path: .
+        executable: som-ast-interp
+        args: "-cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
+    SomSom-bc-interp:
+        path: .
+        executable: som-bc-interp
+        args: "-cp core-lib/Smalltalk:core-lib/TestSuite:core-lib/SomSom/src/compiler:core-lib/SomSom/src/vm:core-lib/SomSom/src/vmobjects:core-lib/SomSom/src/interpreter:core-lib/SomSom/src/primitives core-lib/SomSom/src/vm/Main.som"
+
 
 # define the benchmarks to be executed for a re-executable benchmark run
 experiments:
@@ -132,3 +153,10 @@ experiments:
                     - micro-steady
                     - macro-startup
                     - macro-steady
+    SomSom:
+      description: Just startup benchmarks on SomSom
+      suites:
+        - micro-somsom
+      executions:
+        - SomSom-ast-interp
+        - SomSom-bc-interp

--- a/src/rlib/streamio.py
+++ b/src/rlib/streamio.py
@@ -4,3 +4,24 @@ except ImportError:
     "NOT_RPYTHON"
     def open_file_as_stream(file_name, mode):
         return open(file_name, mode)
+
+
+# Taken from PyPy rpython/rlib/streamio.io (Version 7.3.1)
+def readall_from_stream(stream):
+    bufsize = 8192
+    result = []
+    while True:
+        try:
+            data = stream.read(bufsize)
+        except OSError:
+            # like CPython < 3.4, partial results followed by an error
+            # are returned as data
+            if not result:
+                raise
+            break
+        if not data:
+            break
+        result.append(data)
+        if bufsize < 4194304:    # 4 Megs
+            bufsize <<= 1
+    return ''.join(result)

--- a/src/som/primitives/double_primitives.py
+++ b/src/som/primitives/double_primitives.py
@@ -81,6 +81,14 @@ def _positive_infinity(_rcvr):
     return Double(INFINITY)
 
 
+def _from_string(_rcvr, string):
+    try:
+        return Double(float(string.get_embedded_string()))
+    except ValueError:
+        from som.vm.globals import nilObject
+        return nilObject
+
+
 class DoublePrimitives(Primitives):
 
     def install_primitives(self):
@@ -105,3 +113,4 @@ class DoublePrimitives(Primitives):
         self._install_instance_primitive(UnaryPrimitive("cos", self._universe, _cos))
 
         self._install_class_primitive(UnaryPrimitive("PositiveInfinity", self._universe, _positive_infinity))
+        self._install_class_primitive(BinaryPrimitive("fromString:", self._universe, _from_string))

--- a/src/som/primitives/integer_primitives.py
+++ b/src/som/primitives/integer_primitives.py
@@ -1,4 +1,4 @@
-from rlib.arithmetic import ovfcheck, LONG_BIT, bigint_from_int
+from rlib.arithmetic import ovfcheck, LONG_BIT, bigint_from_int, string_to_int, bigint_from_str, ParseStringOverflowError
 from rlib.llop import as_32_bit_unsigned_value, unsigned_right_shift
 
 from som.primitives.primitives import Primitives
@@ -151,8 +151,16 @@ def _from_string(rcvr, param):
     if not isinstance(param, String):
         return nilObject
 
-    int_value = int(param.get_embedded_string())
-    return Integer(int_value)
+    str_val = param.get_embedded_string()
+
+    from som.vmobjects.integer import Integer
+    try:
+        i = string_to_int(str_val)
+        return Integer(i)
+    except ParseStringOverflowError:
+        from som.vmobjects.biginteger import BigInteger
+        bigint = bigint_from_str(str_val)
+        return BigInteger(bigint)
 
 
 class IntegerPrimitivesBase(Primitives):

--- a/src/som/primitives/integer_primitives.py
+++ b/src/som/primitives/integer_primitives.py
@@ -17,6 +17,10 @@ def _as_string(rcvr):
     return rcvr.prim_as_string()
 
 
+def _as_double(rcvr):
+    return rcvr.prim_as_double()
+
+
 def _as_32_bit_signed_value(rcvr):
     return rcvr.prim_as_32_bit_signed_value()
 
@@ -155,6 +159,7 @@ class IntegerPrimitivesBase(Primitives):
 
     def install_primitives(self):
         self._install_instance_primitive(UnaryPrimitive("asString", self._universe, _as_string))
+        self._install_instance_primitive(UnaryPrimitive("asDouble", self._universe, _as_double))
         self._install_instance_primitive(
             UnaryPrimitive("as32BitSignedValue", self._universe, _as_32_bit_signed_value))
         self._install_instance_primitive(

--- a/src/som/primitives/system_primitives.py
+++ b/src/som/primitives/system_primitives.py
@@ -4,7 +4,7 @@ from rlib import rgc, jit
 
 from som.primitives.primitives import Primitives
 from som.vm.globals import nilObject, trueObject, falseObject
-from som.vm.universe import get_current, std_print, std_println
+from som.vm.universe import get_current, std_print, std_println, error_print, error_println
 from som.vmobjects.primitive import UnaryPrimitive, BinaryPrimitive, TernaryPrimitive
 
 
@@ -44,6 +44,16 @@ def _print_newline(rcvr):
     return rcvr
 
 
+def _error_print(rcvr, string):
+    error_print(string.get_embedded_string())
+    return rcvr
+
+
+def _error_println(rcvr, string):
+    error_println(string.get_embedded_string())
+    return rcvr
+
+
 def _time(rcvr):
     from som.vmobjects.integer import Integer
     since_start = time.time() - get_current().start_time
@@ -72,6 +82,8 @@ class SystemPrimitivesBase(Primitives):
         self._install_instance_primitive(TernaryPrimitive("global:put:", self._universe, _global_put))
         self._install_instance_primitive(BinaryPrimitive("printString:", self._universe, _print_string))
         self._install_instance_primitive(UnaryPrimitive("printNewline", self._universe, _print_newline))
+        self._install_instance_primitive(BinaryPrimitive("errorPrint:", self._universe, _error_print))
+        self._install_instance_primitive(BinaryPrimitive("errorPrintln:", self._universe, _error_println))
 
         self._install_instance_primitive(UnaryPrimitive("time", self._universe, _time))
         self._install_instance_primitive(UnaryPrimitive("ticks", self._universe, _ticks))

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -144,20 +144,22 @@ class Universe(object):
     def handle_arguments(self, arguments):
         got_classpath  = False
         remaining_args = []
+        saw_others = False
 
         i = 0
         while i < len(arguments):
-            if arguments[i] == "-cp":
+            if arguments[i] == "-cp" and not saw_others:
                 if i + 1 >= len(arguments):
                     self._print_usage_and_exit()
                 self.setup_classpath(arguments[i + 1])
                 i += 1    # skip class path
                 got_classpath = True
-            elif arguments[i] == "-d":
+            elif arguments[i] == "-d" and not saw_others:
                 self._dump_bytecodes = True
-            elif arguments[i] in ["-h", "--help", "-?"]:
+            elif arguments[i] in ["-h", "--help", "-?"] and not saw_others:
                 self._print_usage_and_exit()
             else:
+                saw_others = True
                 remaining_args.append(arguments[i])
             i += 1
 
@@ -166,15 +168,13 @@ class Universe(object):
             self.classpath = self._default_classpath()
 
         # check remaining args for class paths, and strip file extension
-        i = 0
-        while i < len(remaining_args):
-            split = self._get_path_class_ext(remaining_args[i])
+        if remaining_args:
+            split = self._get_path_class_ext(remaining_args[0])
 
             if split[0] != "":  # there was a path
                 self.classpath.insert(0, split[0])
 
-            remaining_args[i] = split[1]
-            i += 1
+            remaining_args[0] = split[1]
 
         return remaining_args
 

--- a/src/som/vmobjects/biginteger.py
+++ b/src/som/vmobjects/biginteger.py
@@ -95,6 +95,10 @@ class BigInteger(AbstractObject):
         from .string import String
         return String(self._embedded_biginteger.str())
 
+    def prim_as_double(self):
+        from .double import Double
+        return Double(self._embedded_biginteger.tofloat())
+
     def prim_abs(self):
         return BigInteger(self._embedded_biginteger.abs())
 

--- a/src/som/vmobjects/integer.py
+++ b/src/som/vmobjects/integer.py
@@ -100,6 +100,10 @@ class Integer(AbstractObject):
         from .string import String
         return String(str(self._embedded_integer))
 
+    def prim_as_double(self):
+        from .double import Double
+        return Double(float(self._embedded_integer))
+
     def prim_abs(self):
         return Integer(abs(self._embedded_integer))
 

--- a/src/som/vmobjects/primitive.py
+++ b/src/som/vmobjects/primitive.py
@@ -156,7 +156,8 @@ class _BcTernaryPrimitive(_AbstractPrimitive):
 
 def _empty_invoke(ivkbl, _a, _b):
     """ Write a warning to the screen """
-    print("Warning: undefined primitive %s called" % str(ivkbl.get_signature()))
+    print("Warning: undefined primitive #%s called" %
+          ivkbl.get_signature().get_embedded_string())
 
 
 if is_ast_interpreter():

--- a/tests/test_basic_interpreter.py
+++ b/tests/test_basic_interpreter.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from som.compiler.parse_error import ParseError
@@ -103,7 +104,10 @@ from som.vmobjects.symbol  import Symbol
 def test_basic_interpreter_behavior(test_class, test_selector, expected_result, result_type):
     u = create_universe()
     set_current(u)
-    u.setup_classpath("Smalltalk:TestSuite/BasicInterpreterTests")
+
+    core_lib_path = os.path.dirname(os.path.abspath(__file__)) + "/../core-lib/"
+    u.setup_classpath(core_lib_path + "Smalltalk:"
+                      + core_lib_path + "TestSuite/BasicInterpreterTests")
 
     try:
         actual_result = u.execute_method(test_class, test_selector)

--- a/tests/test_basic_interpreter.py
+++ b/tests/test_basic_interpreter.py
@@ -40,6 +40,11 @@ from som.vmobjects.symbol  import Symbol
         ("IfTrueIfFalse", "test2", 33, Integer),
         ("IfTrueIfFalse", "test3",  4, Integer),
 
+        ("IfTrueIfFalse", "testIfTrueTrueResult",   "Integer", Class),
+        ("IfTrueIfFalse", "testIfTrueFalseResult",  "Nil",     Class),
+        ("IfTrueIfFalse", "testIfFalseTrueResult",  "Nil",     Class),
+        ("IfTrueIfFalse", "testIfFalseFalseResult", "Integer", Class),
+
         ("CompilerSimplification", "testReturnConstantSymbol",  "constant", Symbol),
         ("CompilerSimplification", "testReturnConstantInt",     42, Integer),
         ("CompilerSimplification", "testReturnSelf",            "CompilerSimplification", Class),
@@ -62,8 +67,14 @@ from som.vmobjects.symbol  import Symbol
         ("BlockInlining", "testOneLevelInliningWithLocalShadowTrue", 2, Integer),
         ("BlockInlining", "testOneLevelInliningWithLocalShadowFalse", 1, Integer),
 
+        ("BlockInlining", "testShadowDoesntStoreWrongLocal",    33, Integer),
+        ("BlockInlining", "testShadowDoesntReadUnrelated",   "Nil", Class),
+
         ("BlockInlining", "testBlockNestedInIfTrue",                2, Integer),
         ("BlockInlining", "testBlockNestedInIfFalse",              42, Integer),
+
+        ("BlockInlining", "testStackDisciplineTrue",    1, Integer),
+        ("BlockInlining", "testStackDisciplineFalse",   2, Integer),
 
         ("BlockInlining", "testDeepNestedInlinedIfTrue",            3, Integer),
         ("BlockInlining", "testDeepNestedInlinedIfFalse",          42, Integer),
@@ -87,7 +98,7 @@ from som.vmobjects.symbol  import Symbol
 
         ("BinaryOperation", "test", 3 + 8, Integer),
 
-        ("NumberOfTests", "numberOfTests", 57, Integer),
+        ("NumberOfTests", "numberOfTests", 65, Integer),
     ])
 def test_basic_interpreter_behavior(test_class, test_selector, expected_result, result_type):
     u = create_universe()

--- a/tests/test_som.py
+++ b/tests/test_som.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from som.vm.universe import create_universe, set_current
@@ -32,7 +33,9 @@ from som.vm.universe import create_universe, set_current
         "System"        ,
         "Vector"        ])
 def test_som(test_name):
-    args = ["-cp", "Smalltalk", "TestSuite/TestHarness.som", test_name]
+    core_lib_path = os.path.dirname(os.path.abspath(__file__)) + "/../core-lib/"
+    args = ["-cp", core_lib_path + "Smalltalk",
+            core_lib_path + "TestSuite/TestHarness.som", test_name]
     u = create_universe(True)
     set_current(u)
     u.interpret(args)


### PR DESCRIPTION
This PR adds the primitives needed for SomSom:

- `Double>>#fromString:`
- `System>>#loadFile:` (returns string or nil)
- `System>>#errorPrint:`
- `System>>#errorPrintln:`
- `System>>#printStackTrace`
- `Integer>>#asDouble`

With it, PySOM is able to run SomSom.
Unfortunately, it's rather slow on Python/PyPy.
So, we test only on compiled PySOM interpreters.