### PR TITLE
Add first optimized bytecodes

### DIFF
--- a/src/som/compiler/ast/method_generation_context.py
+++ b/src/som/compiler/ast/method_generation_context.py
@@ -8,7 +8,7 @@ from ..method_generation_context import MethodGenerationContextBase
 from ...interpreter.ast.nodes.field_node import create_write_node, \
                                                       create_read_node
 from ...interpreter.ast.nodes.global_read_node import \
-    UninitializedGlobalReadNode
+    create_global_node
 from ...interpreter.ast.nodes.return_non_local_node import CatchNonLocalReturnNode
 from ...interpreter.ast.invokable import Invokable
 
@@ -182,7 +182,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
                                 self.get_field_index(field_name))
 
     def get_global_read(self, var_name):
-        return UninitializedGlobalReadNode(var_name, self._universe)
+        return create_global_node(var_name, self._universe, None)
 
     def get_object_field_write(self, field_name, exp):
         if not self.has_field(field_name):

--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -63,7 +63,7 @@ class Parser(ParserBase):
     def _create_sequence_node(self, coordinate, expressions):
         if not expressions:
             nil_exp = create_global_node(
-                self._universe.symbol_for("nil"),
+                self._universe.symNil,
                 self._universe,
                 self._get_source_section(coordinate))
             return nil_exp

--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -5,7 +5,7 @@ from ..parse_error import ParseError
 from ..parser import ParserBase
 
 from ...interpreter.ast.nodes.block_node import BlockNode, BlockNodeWithContext
-from ...interpreter.ast.nodes.global_read_node import UninitializedGlobalReadNode
+from ...interpreter.ast.nodes.global_read_node import create_global_node
 from ...interpreter.ast.nodes.literal_node import LiteralNode
 from ...interpreter.ast.nodes.message.uninitialized_node import UninitializedMessageNode
 from ...interpreter.ast.nodes.return_non_local_node import ReturnNonLocalNode
@@ -62,9 +62,11 @@ class Parser(ParserBase):
 
     def _create_sequence_node(self, coordinate, expressions):
         if not expressions:
-            nil_exp = UninitializedGlobalReadNode(
-                self._universe.symbol_for("nil"), self._universe)
-            return self._assign_source(nil_exp, coordinate)
+            nil_exp = create_global_node(
+                self._universe.symbol_for("nil"),
+                self._universe,
+                self._get_source_section(coordinate))
+            return nil_exp
         if len(expressions) == 1:
             return expressions[0]
 

--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -83,8 +83,7 @@ class Parser(ParserBase):
                                       exp, self._universe)
             mgenc.make_catch_non_local_return()
             return self._assign_source(node, coord)
-        else:
-            return exp
+        return exp
 
     def _assignation(self, mgenc):
         return self._assignments(mgenc)
@@ -225,26 +224,22 @@ class Parser(ParserBase):
 
             if self._next_sym == Symbol.NewTerm:
                 return self._literal_array()
-            else:
-                return self._literal_symbol()
+            return self._literal_symbol()
         elif self._sym == Symbol.STString:
             return self._literal_string()
-        else:
-            return self._literal_number()
+        return self._literal_number()
 
     def _literal_number(self):
         if self._sym == Symbol.Minus:
             return self._negative_decimal()
-        else:
-            return self._literal_decimal(False)
+        return self._literal_decimal(False)
 
     def _literal_symbol(self):
         self._expect(Symbol.Pound)
         if self._sym == Symbol.STString:
             s = self._string()
             return self._universe.symbol_for(s)
-        else:
-            return self._selector()
+        return self._selector()
 
     def _literal_string(self):
         s = self._string()

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -1,75 +1,96 @@
 from som.interpreter.bc.bytecodes import Bytecodes as BC
 
 
-class BytecodeGenerator(object):
+def emit_inc(mgenc):
+    _emit1(mgenc, BC.inc)
 
-    def emitINC(self, mgenc):
-        self._emit1(mgenc, BC.inc)
 
-    def emitDEC(self, mgenc):
-        self._emit1(mgenc, BC.dec)
+def emit_dec(mgenc):
+    _emit1(mgenc, BC.dec)
 
-    def emitPOP(self, mgenc):
-        self._emit1(mgenc, BC.pop)
 
-    def emitPUSHARGUMENT(self, mgenc, idx, ctx):
-        self._emit3(mgenc, BC.push_argument, idx, ctx)
+def emit_pop(mgenc):
+    _emit1(mgenc, BC.pop)
 
-    def emitRETURNSELF(self, mgenc):
-        self._emit1(mgenc, BC.return_self)
 
-    def emitRETURNLOCAL(self, mgenc):
-        self._emit1(mgenc, BC.return_local)
+def emit_push_argument(mgenc, idx, ctx):
+    _emit3(mgenc, BC.push_argument, idx, ctx)
 
-    def emitRETURNNONLOCAL(self, mgenc):
-        self._emit2(mgenc, BC.return_non_local, mgenc.get_max_context_level())
 
-    def emitDUP(self, mgenc):
-        self._emit1(mgenc, BC.dup)
+def emit_return_self(mgenc):
+    _emit1(mgenc, BC.return_self)
 
-    def emitPUSHBLOCK(self, mgenc, block_method):
-        self._emit2(mgenc, BC.push_block, mgenc.find_literal_index(block_method))
 
-    def emitPUSHLOCAL(self, mgenc, idx, ctx):
-        self._emit3(mgenc, BC.push_local, idx, ctx)
+def emit_return_local(mgenc):
+    _emit1(mgenc, BC.return_local)
 
-    def emitPUSHFIELD(self, mgenc, field_name):
-        self._emit3(mgenc, BC.push_field,
-                    mgenc.get_field_index(field_name), mgenc.get_max_context_level())
 
-    def emitPUSHGLOBAL(self, mgenc, glob):
-        self._emit2(mgenc, BC.push_global, mgenc.find_literal_index(glob))
+def emit_return_non_local(mgenc):
+    _emit2(mgenc, BC.return_non_local, mgenc.get_max_context_level())
 
-    def emitPOPARGUMENT(self, mgenc, idx, ctx):
-        self._emit3(mgenc, BC.pop_argument, idx, ctx)
 
-    def emitPOPLOCAL(self, mgenc, idx, ctx):
-        self._emit3(mgenc, BC.pop_local, idx, ctx)
+def emit_dup(mgenc):
+    _emit1(mgenc, BC.dup)
 
-    def emitPOPFIELD(self, mgenc, field_name):
-        self._emit3(mgenc, BC.pop_field,
-                    mgenc.get_field_index(field_name), mgenc.get_max_context_level())
 
-    def emitSUPERSEND(self, mgenc, msg):
-        self._emit2(mgenc, BC.super_send, mgenc.find_literal_index(msg))
+def emit_push_block(mgenc, block_method):
+    _emit2(mgenc, BC.push_block, mgenc.find_literal_index(block_method))
 
-    def emitSEND(self, mgenc, msg):
-        self._emit2(mgenc, BC.send, mgenc.find_literal_index(msg))
 
-    def emitPUSHCONSTANT(self, mgenc, lit):
-        self._emit2(mgenc, BC.push_constant, mgenc.find_literal_index(lit))
+def emit_push_local(mgenc, idx, ctx):
+    _emit3(mgenc, BC.push_local, idx, ctx)
 
-    def emitPUSHCONSTANT_index(self, mgenc, lit_index):
-        self._emit2(mgenc, BC.push_constant, lit_index)
 
-    def _emit1(self, mgenc, code):
-        mgenc.add_bytecode(code)
+def emit_push_field(mgenc, field_name):
+    _emit3(mgenc, BC.push_field,
+           mgenc.get_field_index(field_name), mgenc.get_max_context_level())
 
-    def _emit2(self, mgenc, code, idx):
-        mgenc.add_bytecode(code)
-        mgenc.add_bytecode(idx)
 
-    def _emit3(self, mgenc, code, idx, ctx):
-        mgenc.add_bytecode(code)
-        mgenc.add_bytecode(idx)
-        mgenc.add_bytecode(ctx)
+def emit_push_global(mgenc, glob):
+    _emit2(mgenc, BC.push_global, mgenc.find_literal_index(glob))
+
+
+def emit_pop_argument(mgenc, idx, ctx):
+    _emit3(mgenc, BC.pop_argument, idx, ctx)
+
+
+def emit_pop_local(mgenc, idx, ctx):
+    _emit3(mgenc, BC.pop_local, idx, ctx)
+
+
+def emit_pop_field(mgenc, field_name):
+    _emit3(mgenc, BC.pop_field,
+                mgenc.get_field_index(field_name), mgenc.get_max_context_level())
+
+
+def emit_super_send(mgenc, msg):
+    idx = mgenc.add_literal_if_absent(msg)
+    _emit2(mgenc, BC.super_send, idx)
+
+
+def emit_send(mgenc, msg):
+    idx = mgenc.add_literal_if_absent(msg)
+    _emit2(mgenc, BC.send, idx)
+
+
+def emit_push_constant(mgenc, lit):
+    _emit2(mgenc, BC.push_constant, mgenc.find_literal_index(lit))
+
+
+def emit_push_constant_index(mgenc, lit_index):
+    _emit2(mgenc, BC.push_constant, lit_index)
+
+
+def _emit1(mgenc, code):
+    mgenc.add_bytecode(code)
+
+
+def _emit2(mgenc, code, idx):
+    mgenc.add_bytecode(code)
+    mgenc.add_bytecode(idx)
+
+
+def _emit3(mgenc, code, idx, ctx):
+    mgenc.add_bytecode(code)
+    mgenc.add_bytecode(idx)
+    mgenc.add_bytecode(ctx)

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -50,17 +50,6 @@ class BytecodeGenerator(object):
     def emitSEND(self, mgenc, msg):
         self._emit2(mgenc, BC.send, mgenc.find_literal_index(msg))
 
-    def emitQUICKSEND(self, mgenc, msg):
-        m = msg.get_embedded_string()
-        if m == "+":
-            self._emit1(mgenc, BC.add)
-        elif m == "*":
-            self._emit1(mgenc, BC.multiply)
-        elif m == "-":
-            self._emit1(mgenc, BC.subtract)
-        else:
-            raise RuntimeError("Unsupported msg: " + str(msg))
-
     def emitPUSHCONSTANT(self, mgenc, lit):
         self._emit2(mgenc, BC.push_constant, mgenc.find_literal_index(lit))
 

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -13,7 +13,7 @@ class BytecodeGenerator(object):
         self._emit1(mgenc, BC.return_local)
 
     def emitRETURNNONLOCAL(self, mgenc):
-        self._emit1(mgenc, BC.return_non_local)
+        self._emit2(mgenc, BC.return_non_local, mgenc.get_max_context_level())
 
     def emitDUP(self, mgenc):
         self._emit1(mgenc, BC.dup)
@@ -25,7 +25,8 @@ class BytecodeGenerator(object):
         self._emit3(mgenc, BC.push_local, idx, ctx)
 
     def emitPUSHFIELD(self, mgenc, field_name):
-        self._emit2(mgenc, BC.push_field, mgenc.get_field_index(field_name))
+        self._emit3(mgenc, BC.push_field,
+                    mgenc.get_field_index(field_name), mgenc.get_max_context_level())
 
     def emitPUSHGLOBAL(self, mgenc, glob):
         self._emit2(mgenc, BC.push_global, mgenc.find_literal_index(glob))
@@ -37,7 +38,8 @@ class BytecodeGenerator(object):
         self._emit3(mgenc, BC.pop_local, idx, ctx)
 
     def emitPOPFIELD(self, mgenc, field_name):
-        self._emit2(mgenc, BC.pop_field, mgenc.get_field_index(field_name))
+        self._emit3(mgenc, BC.pop_field,
+                    mgenc.get_field_index(field_name), mgenc.get_max_context_level())
 
     def emitSUPERSEND(self, mgenc, msg):
         self._emit2(mgenc, BC.super_send, mgenc.find_literal_index(msg))

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -9,6 +9,9 @@ class BytecodeGenerator(object):
     def emitPUSHARGUMENT(self, mgenc, idx, ctx):
         self._emit3(mgenc, BC.push_argument, idx, ctx)
 
+    def emitRETURNSELF(self, mgenc):
+        self._emit1(mgenc, BC.return_self)
+
     def emitRETURNLOCAL(self, mgenc):
         self._emit1(mgenc, BC.return_local)
 

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -3,6 +3,12 @@ from som.interpreter.bc.bytecodes import Bytecodes as BC
 
 class BytecodeGenerator(object):
 
+    def emitINC(self, mgenc):
+        self._emit1(mgenc, BC.inc)
+
+    def emitDEC(self, mgenc):
+        self._emit1(mgenc, BC.dec)
+
     def emitPOP(self, mgenc):
         self._emit1(mgenc, BC.pop)
 

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -79,10 +79,10 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
     def add_literal_if_absent(self, lit):
         if lit in self._literals:
-            return False
+            return self._literals.index(lit)
 
         self._literals.append(lit)
-        return True
+        return len(self._literals) - 1
 
     def add_literal(self, lit):
         i = len(self._literals)

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -113,6 +113,11 @@ class MethodGenerationContext(MethodGenerationContextBase):
         else:
             return False
 
+    def get_max_context_level(self):
+        if self._outer_genc is None:
+            return 0
+        return 1 + self._outer_genc.get_max_context_level()
+
     def add_bytecode(self, bc):
         self._bytecode.append(bc)
 

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -20,9 +20,9 @@ class Parser(ParserBase):
         # terminating the last expression, so the last expression's value must
         # be popped off the stack and a ^self be generated
         if not mgenc.is_finished():
-            self._bc_gen.emitPOP(mgenc)
-            self._bc_gen.emitPUSHARGUMENT(mgenc, 0, 0)
-            self._bc_gen.emitRETURNLOCAL(mgenc)
+            # with RETURN_SELF, we don't need the extra stack space
+            # self._bc_gen.emitPOP(mgenc)
+            self._bc_gen.emitRETURNSELF(mgenc)
             mgenc.set_finished()
 
         self._expect(Symbol.EndTerm)
@@ -50,8 +50,7 @@ class Parser(ParserBase):
             # it does not matter whether a period has been seen, as the end of
             # the method has been found (EndTerm) - so it is safe to emit a
             # "return self"
-            self._bc_gen.emitPUSHARGUMENT(mgenc, 0, 0)
-            self._bc_gen.emitRETURNLOCAL(mgenc)
+            self._bc_gen.emitRETURNSELF(mgenc)
             mgenc.set_finished()
         else:
             self._expression(mgenc)

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -165,7 +165,6 @@ class Parser(ParserBase):
 
     def _unary_message(self, mgenc, is_super_send):
         msg = self._unary_selector()
-        mgenc.add_literal_if_absent(msg)
 
         if is_super_send:
             emit_super_send(mgenc, msg)
@@ -186,7 +185,6 @@ class Parser(ParserBase):
 
     def _binary_message(self, mgenc, is_super_send):
         msg = self._binary_selector()
-        mgenc.add_literal_if_absent(msg)
 
         if self._try_inc_or_dec_bytecodes(msg, is_super_send, mgenc):
             return
@@ -216,8 +214,6 @@ class Parser(ParserBase):
             self._formula(mgenc)
 
         msg = self._universe.symbol_for(kw)
-
-        mgenc.add_literal_if_absent(msg)
 
         if is_super_send:
             emit_super_send(mgenc, msg)
@@ -285,9 +281,6 @@ class Parser(ParserBase):
         at_put_message = self._universe.symbol_for("at:put:")
 
         mgenc.add_literal_if_absent(array_class_name)
-        mgenc.add_literal_if_absent(new_message)
-        mgenc.add_literal_if_absent(at_put_message)
-
         array_size_literal_idx = mgenc.add_literal(array_size_placeholder)
 
         # create empty array

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -173,11 +173,6 @@ class Parser(ParserBase):
         else:
             self._bc_gen.emitSEND(mgenc, msg)
 
-    @staticmethod
-    def _is_quick_send(msg):
-        m = msg.get_embedded_string()
-        return m == "+" or m == "-" or m == "*"
-
     def _binary_message(self, mgenc, is_super_send):
         msg = self._binary_selector()
         mgenc.add_literal_if_absent(msg)
@@ -186,8 +181,6 @@ class Parser(ParserBase):
 
         if is_super_send:
             self._bc_gen.emitSUPERSEND(mgenc, msg)
-        elif self._is_quick_send(msg):
-            self._bc_gen.emitQUICKSEND(mgenc, msg)
         else:
             self._bc_gen.emitSEND(mgenc, msg)
 

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -1,4 +1,4 @@
-from .bytecode_generator import BytecodeGenerator
+from .bytecode_generator import emit_inc, emit_dec, emit_dup, emit_pop, emit_send, emit_pop_field, emit_pop_local, emit_return_local, emit_return_self, emit_super_send, emit_push_field, emit_push_global, emit_push_block, emit_push_local, emit_push_argument, emit_pop_argument, emit_push_constant, emit_push_constant_index, emit_return_non_local
 from .method_generation_context import MethodGenerationContext
 from ..parser import ParserBase
 from ..symbol import Symbol
@@ -10,7 +10,6 @@ class Parser(ParserBase):
 
     def __init__(self, reader, file_name, universe):
         ParserBase.__init__(self, reader, file_name, universe)
-        self._bc_gen = BytecodeGenerator()
 
     def _method_block(self, mgenc):
         self._expect(Symbol.NewTerm)
@@ -22,7 +21,7 @@ class Parser(ParserBase):
         if not mgenc.is_finished():
             # with RETURN_SELF, we don't need the extra stack space
             # self._bc_gen.emitPOP(mgenc)
-            self._bc_gen.emitRETURNSELF(mgenc)
+            emit_return_self(mgenc)
             mgenc.set_finished()
 
         self._expect(Symbol.EndTerm)
@@ -42,20 +41,20 @@ class Parser(ParserBase):
             if mgenc.is_block_method() and not mgenc.has_bytecode():
                 nil_sym = self._universe.symbol_for("nil")
                 mgenc.add_literal_if_absent(nil_sym)
-                self._bc_gen.emitPUSHGLOBAL(mgenc, nil_sym)
+                emit_push_global(mgenc, nil_sym)
 
-            self._bc_gen.emitRETURNLOCAL(mgenc)
+            emit_return_local(mgenc)
             mgenc.set_finished()
         elif self._sym == Symbol.EndTerm:
             # it does not matter whether a period has been seen, as the end of
             # the method has been found (EndTerm) - so it is safe to emit a
             # "return self"
-            self._bc_gen.emitRETURNSELF(mgenc)
+            emit_return_self(mgenc)
             mgenc.set_finished()
         else:
             self._expression(mgenc)
             if self._accept(Symbol.Period):
-                self._bc_gen.emitPOP(mgenc)
+                emit_pop(mgenc)
                 self._block_body(mgenc, True)
 
     def _result(self, mgenc):
@@ -63,9 +62,9 @@ class Parser(ParserBase):
         self._accept(Symbol.Period)
 
         if mgenc.is_block_method():
-            self._bc_gen.emitRETURNNONLOCAL(mgenc)
+            emit_return_non_local(mgenc)
         else:
-            self._bc_gen.emitRETURNLOCAL(mgenc)
+            emit_return_local(mgenc)
 
         mgenc.set_finished()
 
@@ -76,7 +75,7 @@ class Parser(ParserBase):
         self._evaluation(mgenc)
 
         for _assignment in l:
-            self._bc_gen.emitDUP(mgenc)
+            emit_dup(mgenc)
 
         for assignment in l:
             self._gen_pop_variable(mgenc, assignment)
@@ -130,7 +129,7 @@ class Parser(ParserBase):
 
             block_method = bgenc.assemble(None)
             mgenc.add_literal(block_method)
-            self._bc_gen.emitPUSHBLOCK(mgenc, block_method)
+            emit_push_block(mgenc, block_method)
         else:
             self._literal(mgenc)
 
@@ -169,9 +168,9 @@ class Parser(ParserBase):
         mgenc.add_literal_if_absent(msg)
 
         if is_super_send:
-            self._bc_gen.emitSUPERSEND(mgenc, msg)
+            emit_super_send(mgenc, msg)
         else:
-            self._bc_gen.emitSEND(mgenc, msg)
+            emit_send(mgenc, msg)
 
     def _try_inc_or_dec_bytecodes(self, msg, is_super_send, mgenc):
         is_inc_or_dec = msg is self._universe.symPlus or msg is self._universe.symMinus
@@ -179,9 +178,9 @@ class Parser(ParserBase):
             if self._sym == Symbol.Integer and self._text == "1":
                 self._expect(Symbol.Integer)
                 if msg is self._universe.symPlus:
-                    self._bc_gen.emitINC(mgenc)
+                    emit_inc(mgenc)
                 else:
-                    self._bc_gen.emitDEC(mgenc)
+                    emit_dec(mgenc)
                 return True
         return False
 
@@ -195,9 +194,9 @@ class Parser(ParserBase):
         self._binary_operand(mgenc)
 
         if is_super_send:
-            self._bc_gen.emitSUPERSEND(mgenc, msg)
+            emit_super_send(mgenc, msg)
         else:
-            self._bc_gen.emitSEND(mgenc, msg)
+            emit_send(mgenc, msg)
 
     def _binary_operand(self, mgenc):
         is_super_send = self._primary(mgenc)
@@ -221,9 +220,9 @@ class Parser(ParserBase):
         mgenc.add_literal_if_absent(msg)
 
         if is_super_send:
-            self._bc_gen.emitSUPERSEND(mgenc, msg)
+            emit_super_send(mgenc, msg)
         else:
-            self._bc_gen.emitSEND(mgenc, msg)
+            emit_send(mgenc, msg)
 
     def _formula(self, mgenc):
         is_super_send = self._binary_operand(mgenc)
@@ -255,7 +254,7 @@ class Parser(ParserBase):
             lit = self._literal_decimal(False)
 
         mgenc.add_literal_if_absent(lit)
-        self._bc_gen.emitPUSHCONSTANT(mgenc, lit)
+        emit_push_constant(mgenc, lit)
 
     def _literal_symbol(self, mgenc):
         self._expect(Symbol.Pound)
@@ -266,7 +265,7 @@ class Parser(ParserBase):
             symb = self._selector()
 
         mgenc.add_literal_if_absent(symb)
-        self._bc_gen.emitPUSHCONSTANT(mgenc, symb)
+        emit_push_constant(mgenc, symb)
 
     def _literal_string(self, mgenc):
         s = self._string()
@@ -274,7 +273,7 @@ class Parser(ParserBase):
         string = String(s)
         mgenc.add_literal_if_absent(string)
 
-        self._bc_gen.emitPUSHCONSTANT(mgenc, string)
+        emit_push_constant(mgenc, string)
 
     def _literal_array(self, mgenc):
         self._expect(Symbol.Pound)
@@ -292,19 +291,19 @@ class Parser(ParserBase):
         array_size_literal_idx = mgenc.add_literal(array_size_placeholder)
 
         # create empty array
-        self._bc_gen.emitPUSHGLOBAL(mgenc, array_class_name)
-        self._bc_gen.emitPUSHCONSTANT_index(mgenc, array_size_literal_idx)
-        self._bc_gen.emitSEND(mgenc, new_message)
+        emit_push_global(mgenc, array_class_name)
+        emit_push_constant_index(mgenc, array_size_literal_idx)
+        emit_send(mgenc, new_message)
 
         i = 1
 
         while self._sym != Symbol.EndTerm:
             push_idx = Integer(i)
             mgenc.add_literal_if_absent(push_idx)
-            self._bc_gen.emitPUSHCONSTANT(mgenc, push_idx)
+            emit_push_constant(mgenc, push_idx)
 
             self._literal(mgenc)
-            self._bc_gen.emitSEND(mgenc, at_put_message)
+            emit_send(mgenc, at_put_message)
             i += 1
 
         mgenc.update_literal(
@@ -322,8 +321,8 @@ class Parser(ParserBase):
             if not mgenc.has_bytecode():
                 nil_sym = self._universe.symNil
                 mgenc.add_literal_if_absent(nil_sym)
-                self._bc_gen.emitPUSHGLOBAL(mgenc, nil_sym)
-            self._bc_gen.emitRETURNLOCAL(mgenc)
+                emit_push_global(mgenc, nil_sym)
+            emit_return_local(mgenc)
             mgenc.set_finished()
 
         self._expect(Symbol.EndBlock)
@@ -339,19 +338,19 @@ class Parser(ParserBase):
 
         if mgenc.find_var(var, triplet):
             if triplet[2]:
-                self._bc_gen.emitPUSHARGUMENT(mgenc, triplet[0], triplet[1])
+                emit_push_argument(mgenc, triplet[0], triplet[1])
             else:
-                self._bc_gen.emitPUSHLOCAL(mgenc, triplet[0], triplet[1])
+                emit_push_local(mgenc, triplet[0], triplet[1])
         else:
             identifier = self._universe.symbol_for(var)
             if mgenc.has_field(identifier):
                 field_name = identifier
                 mgenc.add_literal_if_absent(field_name)
-                self._bc_gen.emitPUSHFIELD(mgenc, field_name)
+                emit_push_field(mgenc, field_name)
             else:
                 globe = identifier
                 mgenc.add_literal_if_absent(globe)
-                self._bc_gen.emitPUSHGLOBAL(mgenc, globe)
+                emit_push_global(mgenc, globe)
 
     def _gen_pop_variable(self, mgenc, var):
         # The purpose of this function is to find out whether the variable to be
@@ -364,8 +363,8 @@ class Parser(ParserBase):
 
         if mgenc.find_var(var, triplet):
             if triplet[2]:
-                self._bc_gen.emitPOPARGUMENT(mgenc, triplet[0], triplet[1])
+                emit_pop_argument(mgenc, triplet[0], triplet[1])
             else:
-                self._bc_gen.emitPOPLOCAL(mgenc, triplet[0], triplet[1])
+                emit_pop_local(mgenc, triplet[0], triplet[1])
         else:
-            self._bc_gen.emitPOPFIELD(mgenc, self._universe.symbol_for(var))
+            emit_pop_field(mgenc, self._universe.symbol_for(var))

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -20,13 +20,14 @@ class Bytecodes(object):
     super_send       = 13
     return_local     = 14
     return_non_local = 15
+    return_self      = 16
 
     # quick sends, short cutting well known operations
-    add              = 16
-    multiply         = 17
-    subtract         = 18
+    add              = 17
+    multiply         = 18
+    subtract         = 19
 
-    _num_bytecodes   = 19
+    _num_bytecodes   = 20
 
     _bytecode_length = [ 1, # halt
                          1,  # dup
@@ -44,6 +45,7 @@ class Bytecodes(object):
                          2,  # super_send
                          1,  # return_local
                          2,  # return_non_local
+                         1,  # return_self
 
                          1,  # add
                          1,  # multiply
@@ -68,10 +70,12 @@ class Bytecodes(object):
                               _stack_effect_depends_on_message, # super_send
                                0,                               # return_local
                                0,                               # return_non_local
+                               0,                               # return_self
                               -1,                               # add
                               -1,                               # multiply
                               -1,                               # subtract
                               ]
+
 
 @jit.elidable
 def bytecode_length(bytecode):
@@ -83,7 +87,8 @@ def bytecode_length(bytecode):
 def bytecode_stack_effect(bytecode, number_of_arguments_of_message_send = 0):
     assert 0 <= bytecode < len(Bytecodes._bytecode_stack_effect)
     if bytecode_stack_effect_depends_on_send(bytecode):
-        return -number_of_arguments_of_message_send + 1 # +1 in order to account for the return value
+        # +1 in order to account for the return value
+        return -number_of_arguments_of_message_send + 1
     else:
         return Bytecodes._bytecode_stack_effect[bytecode]
 

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -32,18 +32,18 @@ class Bytecodes(object):
                          1,  # dup
                          3,  # push_local
                          3,  # push_argument
-                         2,  # push_field
+                         3,  # push_field
                          2,  # push_block
                          2,  # push_constant
                          2,  # push_global
                          1,  # pop
                          3,  # pop_local
                          3,  # pop_argument
-                         2,  # pop_field
+                         3,  # pop_field
                          2,  # send
                          2,  # super_send
                          1,  # return_local
-                         1,  # return_non_local
+                         2,  # return_non_local
 
                          1,  # add
                          1,  # multiply

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -22,12 +22,7 @@ class Bytecodes(object):
     return_non_local = 15
     return_self      = 16
 
-    # quick sends, short cutting well known operations
-    add              = 17
-    multiply         = 18
-    subtract         = 19
-
-    _num_bytecodes   = 20
+    _num_bytecodes   = 17
 
     _bytecode_length = [ 1, # halt
                          1,  # dup
@@ -46,13 +41,9 @@ class Bytecodes(object):
                          1,  # return_local
                          2,  # return_non_local
                          1,  # return_self
-
-                         1,  # add
-                         1,  # multiply
-                         1,  # subtract
                          ]
 
-    _stack_effect_depends_on_message = -1000 # chose a unresonable number to be recognizable
+    _stack_effect_depends_on_message = -1000  # chose a unreasonable number to be recognizable
 
     _bytecode_stack_effect = [ 0,                               # halt
                                1,                               # dup
@@ -71,9 +62,6 @@ class Bytecodes(object):
                                0,                               # return_local
                                0,                               # return_non_local
                                0,                               # return_self
-                              -1,                               # add
-                              -1,                               # multiply
-                              -1,                               # subtract
                               ]
 
 
@@ -112,4 +100,6 @@ def _sorted_bytecode_names(cls):
     return [key.upper() for value, key in
             sorted([(value, key) for key, value in cls.__dict__.items()
                     if isinstance(value, int) and key[0] != "_"])]
+
+
 _bytecode_names = _sorted_bytecode_names(Bytecodes)

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -22,6 +22,9 @@ class Bytecodes(object):
     return_non_local = 15
     return_self      = 16
 
+    inc              = 17
+    dec              = 18
+
     _num_bytecodes   = 17
 
     _bytecode_length = [ 1, # halt
@@ -41,6 +44,8 @@ class Bytecodes(object):
                          1,  # return_local
                          2,  # return_non_local
                          1,  # return_self
+                         1,  # inc
+                         1,  # dec
                          ]
 
     _stack_effect_depends_on_message = -1000  # chose a unreasonable number to be recognizable
@@ -62,6 +67,8 @@ class Bytecodes(object):
                                0,                               # return_local
                                0,                               # return_non_local
                                0,                               # return_self
+                               0,                               # inc
+                               0,                               # dec
                               ]
 
 

--- a/src/som/interpreter/bc/frame.py
+++ b/src/som/interpreter/bc/frame.py
@@ -44,7 +44,7 @@ class Frame(object):
         return self._context is not None
 
     @jit.unroll_safe
-    def _get_context(self, level):
+    def get_context_at(self, level):
         """ Get the context frame at the given level """
         frame = self
 
@@ -120,24 +120,24 @@ class Frame(object):
 
     def get_local(self, index, context_level):
         # Get the local with the given index in the given context
-        return self._get_context(context_level)._get_local(index)
+        return self.get_context_at(context_level)._get_local(index)
 
     def set_local(self, index, context_level, value):
         # Set the local with the given index in the given context to the given
         # value
         assert value is not None
-        self._get_context(context_level)._set_local(index, value)
+        self.get_context_at(context_level)._set_local(index, value)
 
     def get_argument(self, index, context_level):
         # Get the context
-        context = self._get_context(context_level)
+        context = self.get_context_at(context_level)
 
         # Get the argument with the given index
         return context._stack[index]
 
     def set_argument(self, index, context_level, value):
         # Get the context
-        context = self._get_context(context_level)
+        context = self.get_context_at(context_level)
 
         # Set the argument with the given index to the given value
         context._stack[index] = value

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -165,8 +165,44 @@ class Interpreter(object):
                 return self._do_return_non_local(frame, method.get_bytecode(current_bc_idx + 1))
             elif bytecode == Bytecodes.return_self:
                 return frame.get_argument(0, 0)
+            elif bytecode == Bytecodes.inc:
+                val = frame.top()
+                from som.vmobjects.integer import Integer
+                from som.vmobjects.double import Double
+                from som.vmobjects.biginteger import BigInteger
+                if isinstance(val, Integer):
+                    result = val.prim_inc()
+                elif isinstance(val, Double):
+                    result = val.prim_inc()
+                elif isinstance(val, BigInteger):
+                    result = val.prim_inc()
+                else:
+                    return self._not_yet_implemented()
+                frame.set_top(result)
+            elif bytecode == Bytecodes.dec:
+                val = frame.top()
+                from som.vmobjects.integer import Integer
+                from som.vmobjects.double import Double
+                from som.vmobjects.biginteger import BigInteger
+                if isinstance(val, Integer):
+                    result = val.prim_dec()
+                elif isinstance(val, Double):
+                    result = val.prim_dec()
+                elif isinstance(val, BigInteger):
+                    result = val.prim_dec()
+                else:
+                    return self._not_yet_implemented()
+                frame.set_top(result)
+            else:
+                self._unknown_bytecode(bytecode)
 
             current_bc_idx = next_bc_idx
+
+    def _not_yet_implemented(self):
+        raise Exception("Not yet implemented")
+
+    def _unknown_bytecode(self, bytecode):
+        raise Exception("Unknown bytecode: " + str(bytecode))
 
     @staticmethod
     def get_self(frame, ctx_level):

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -8,18 +8,10 @@ from rlib import jit
 
 class Interpreter(object):
 
-    _immutable_fields_ = ["_universe", "_add_symbol"]
+    _immutable_fields_ = ["_universe"]
 
     def __init__(self, universe):
         self._universe   = universe
-        self._add_symbol      = None
-        self._multiply_symbol = None
-        self._subtract_symbol = None
-
-    def initialize_known_quick_sends(self):
-        self._add_symbol      = self._universe.symbol_for("+")
-        self._multiply_symbol = self._universe.symbol_for("*")
-        self._subtract_symbol = self._universe.symbol_for("-")
 
     def get_universe(self):
         return self._universe
@@ -88,18 +80,6 @@ class Interpreter(object):
             return frame.top()
 
         raise ReturnException(result, context)
-
-    def _do_add(self, bytecode_index, frame, method):
-        rcvr  = frame.get_stack_element(1)
-        rcvr.quick_add(method, frame, self, bytecode_index)
-
-    def _do_multiply(self, bytecode_index, frame, method):
-        rcvr  = frame.get_stack_element(1)
-        rcvr.quick_multiply(method, frame, self, bytecode_index)
-
-    def _do_subtract(self, bytecode_index, frame, method):
-        rcvr  = frame.get_stack_element(1)
-        rcvr.quick_subtract(method, frame, self, bytecode_index)
 
     def _do_send(self, bytecode_index, frame, method):
         # Handle the send bytecode
@@ -185,12 +165,6 @@ class Interpreter(object):
                 return self._do_return_non_local(frame, method.get_bytecode(current_bc_idx + 1))
             elif bytecode == Bytecodes.return_self:
                 return frame.get_argument(0, 0)
-            elif bytecode == Bytecodes.add:
-                self._do_add(current_bc_idx, frame, method)
-            elif bytecode == Bytecodes.multiply:
-                self._do_multiply(current_bc_idx, frame, method)
-            elif bytecode == Bytecodes.subtract:
-                self._do_subtract(current_bc_idx, frame, method)
 
             current_bc_idx = next_bc_idx
 

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -232,6 +232,8 @@ class Interpreter(object):
                 return self._do_return_local(frame)
             elif bytecode == Bytecodes.return_non_local:                # BC:15
                 return self._do_return_non_local(frame, method.get_bytecode(current_bc_idx + 1))
+            elif bytecode == Bytecodes.return_self:
+                return frame.get_argument(0, 0)
             elif bytecode == Bytecodes.add:
                 self._do_add(current_bc_idx, frame, method)
             elif bytecode == Bytecodes.multiply:

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -514,7 +514,6 @@ class _BCUniverse(Universe):
 
     def _initialize_object_system(self):
         system_object = Universe._initialize_object_system(self)
-        self._interpreter.initialize_known_quick_sends()
         return system_object
 
 

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -390,6 +390,9 @@ class Universe(object):
             self._globals[name] = assoc
         return assoc
 
+    def get_globals_association_or_none(self, name):
+        return self._globals.get(name, None)
+
     def _get_block_class(self, number_of_arguments):
         return self.blockClasses[number_of_arguments]
 

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -95,6 +95,10 @@ class Universe(object):
         self.stringClass    = None
         self.doubleClass    = None
 
+        self.symNil = None
+        self.symPlus = None
+        self.symMinus = None
+
         self._last_exit_code = 0
         self._avoid_exit     = avoid_exit
         self._dump_bytecodes = False
@@ -266,8 +270,12 @@ class Universe(object):
         self.systemClass = self.load_class(self.symbol_for("System"))
         system_object = self.new_instance(self.systemClass)
 
+        self.symNil = self.symbol_for("nil")
+        self.symPlus = self.symbol_for("+")
+        self.symMinus = self.symbol_for("+")
+
         # Put special objects and classes into the dictionary of globals
-        self.set_global(self.symbol_for("nil"),    nilObject)
+        self.set_global(self.symNil,               nilObject)
         self.set_global(self.symbol_for("true"),   trueObject)
         self.set_global(self.symbol_for("false"),  falseObject)
         self.set_global(self.symbol_for("system"), system_object)

--- a/src/som/vmobjects/abstract_object.py
+++ b/src/som/vmobjects/abstract_object.py
@@ -6,21 +6,6 @@ class AbstractObject(object):
     def get_class(self, universe):
         raise NotImplementedError("Subclasses need to implement get_class(universe).")
 
-    def quick_add(self, from_method, frame, interpreter, bytecode_index):
-        interpreter._send(from_method, frame, interpreter._add_symbol,
-                          self.get_class(interpreter.get_universe()),
-                          bytecode_index)
-
-    def quick_multiply(self, from_method, frame, interpreter, bytecode_index):
-        interpreter._send(from_method, frame, interpreter._multiply_symbol,
-                          self.get_class(interpreter.get_universe()),
-                          bytecode_index)
-
-    def quick_subtract(self, from_method, frame, interpreter, bytecode_index):
-        interpreter._send(from_method, frame, interpreter._subtract_symbol,
-                          self.get_class(interpreter.get_universe()),
-                          bytecode_index)
-
     @staticmethod
     def is_invokable():
         return False

--- a/src/som/vmobjects/biginteger.py
+++ b/src/som/vmobjects/biginteger.py
@@ -104,6 +104,12 @@ class BigInteger(AbstractObject):
             return right
         return self
 
+    def prim_inc(self):
+        return BigInteger(bigint_from_int(1).add(self._embedded_biginteger))
+
+    def prim_dec(self):
+        return BigInteger(bigint_from_int(1).sub(self._embedded_biginteger))
+
     def prim_add(self, right):
         from .double import Double
         if isinstance(right, BigInteger):

--- a/src/som/vmobjects/biginteger.py
+++ b/src/som/vmobjects/biginteger.py
@@ -21,21 +21,6 @@ class BigInteger(AbstractObject):
     def get_class(self, universe):
         return universe.integerClass
 
-    def quick_add(self, from_method, frame, interpreter, bytecode_index):
-        right = frame.pop()
-        frame.pop()
-        frame.push(self.prim_add(right))
-
-    def quick_multiply(self, from_method, frame, interpreter, bytecode_index):
-        right = frame.pop()
-        frame.pop()
-        frame.push(self.prim_multiply(right))
-
-    def quick_subtract(self, from_method, frame, interpreter, bytecode_index):
-        right = frame.pop()
-        frame.pop()
-        frame.push(self.prim_subtract(right))
-
     def _to_double(self):
         from .double import Double
         return Double(self._embedded_biginteger.tofloat())

--- a/src/som/vmobjects/double.py
+++ b/src/som/vmobjects/double.py
@@ -39,6 +39,12 @@ class Double(AbstractObject):
         r = self._get_float(right)
         return Double(self._embedded_double * r)
 
+    def prim_inc(self):
+        return Double(self._embedded_double + 1.0)
+
+    def prim_dec(self):
+        return Double(self._embedded_double - 1.0)
+
     def prim_add(self, right):
         r = self._get_float(right)
         return Double(self._embedded_double + r)

--- a/src/som/vmobjects/double.py
+++ b/src/som/vmobjects/double.py
@@ -23,21 +23,6 @@ class Double(AbstractObject):
     def get_class(self, universe):
         return universe.doubleClass
 
-    def quick_add(self, from_method, frame, interpreter, bytecode_index):
-        right = frame.pop()
-        frame.pop()
-        frame.push(self.prim_add(right))
-
-    def quick_multiply(self, from_method, frame, interpreter, bytecode_index):
-        right = frame.pop()
-        frame.pop()
-        frame.push(self.prim_multiply(right))
-
-    def quick_subtract(self, from_method, frame, interpreter, bytecode_index):
-        right = frame.pop()
-        frame.pop()
-        frame.push(self.prim_subtract(right))
-
     @staticmethod
     def _get_float(obj):
         from .integer import Integer

--- a/src/som/vmobjects/integer.py
+++ b/src/som/vmobjects/integer.py
@@ -23,24 +23,6 @@ class Integer(AbstractObject):
     def get_class(self, universe):
         return universe.integerClass
 
-    def quick_add(self, from_method, frame, interpreter, bytecode_index):
-        right = frame.top()
-        frame.pop()
-        frame.pop()
-        frame.push(self.prim_add(right))
-
-    def quick_multiply(self, from_method, frame, interpreter, bytecode_index):
-        right = frame.top()
-        frame.pop()
-        frame.pop()
-        frame.push(self.prim_multiply(right))
-
-    def quick_subtract(self, from_method, frame, interpreter, bytecode_index):
-        right = frame.top()
-        frame.pop()
-        frame.pop()
-        frame.push(self.prim_subtract(right))
-
     def _to_double(self):
         from .double import Double
         return Double(float(self._embedded_integer))

--- a/src/som/vmobjects/integer.py
+++ b/src/som/vmobjects/integer.py
@@ -105,6 +105,26 @@ class Integer(AbstractObject):
             return right
         return self
 
+    def prim_inc(self):
+        from .biginteger import BigInteger
+        l = self._embedded_integer
+        try:
+            result = ovfcheck(l + 1)
+            return Integer(result)
+        except OverflowError:
+            return BigInteger(
+                bigint_from_int(l).add(bigint_from_int(1)))
+
+    def prim_dec(self):
+        from .biginteger import BigInteger
+        l = self._embedded_integer
+        try:
+            result = ovfcheck(l - 1)
+            return Integer(result)
+        except OverflowError:
+            return BigInteger(
+                bigint_from_int(l).sub(bigint_from_int(1)))
+
     def prim_add(self, right):
         from .double import Double
         from .biginteger import BigInteger


### PR DESCRIPTION
The main optimizations are:
 - encode context level in push/pop field and return non-local bytecodes
 - add `RETURN_SELF`
 - add `INC` and `DEC`
 
To be in-sync with TruffleSOM, the add, multiple, and subtract bytecodes are removed.

This PR also inlines some of the bytecode logic directly into the bytecode loop to make the code more concise and direct.

There are a few minor changes, including avoiding a uninitialized global node, when the global is known at parse time.