### PR TITLE
Make super a special send and cache lookup directly

### DIFF
--- a/src/som/compiler/ast/variable.py
+++ b/src/som/compiler/ast/variable.py
@@ -1,7 +1,7 @@
 from som.interpreter.ast.nodes.variable_node import UninitializedReadNode, \
     UninitializedWriteNode, LocalSharedWriteNode, LocalUnsharedWriteNode, \
-    NonLocalArgumentReadNode, NonLocalArgumentWriteNode, LocalSuperReadNode, \
-    NonLocalTempReadNode, NonLocalTempWriteNode, NonLocalSuperReadNode, \
+    NonLocalArgumentReadNode, NonLocalArgumentWriteNode, \
+    NonLocalTempReadNode, NonLocalTempWriteNode, \
     LocalArgumentReadNode, LocalArgumentWriteNode, LocalSelfReadNode, NonLocalSelfReadNode, \
     LocalUnsharedTempReadNode, LocalSharedTempReadNode
 
@@ -73,17 +73,6 @@ class Argument(_Variable):
 
     def get_argument_index(self):
         return self._arg_idx
-
-    def get_super_read_node(self, context_level, holder_class_name,
-                            on_class_side, universe):
-        self._is_read = True
-        if context_level > 0:
-            self._is_read_out_of_context = True
-            return NonLocalSuperReadNode(context_level, holder_class_name,
-                                         on_class_side, universe)
-        else:
-            return LocalSuperReadNode(holder_class_name, on_class_side,
-                                      universe, None)
 
     def is_self(self):
         return self._name == "self"

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -64,7 +64,11 @@ def emit_pop_field(mgenc, field_name):
 
 
 def emit_super_send(mgenc, msg):
-    idx = mgenc.add_literal_if_absent(msg)
+    super_class = mgenc.get_holder().get_super_class()
+    method = super_class.lookup_invokable(msg)
+    if not method:
+        raise Exception("Not yet implemented")
+    idx = mgenc.add_literal_if_absent(method)
     _emit2(mgenc, BC.super_send, idx)
 
 

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -64,11 +64,7 @@ def emit_pop_field(mgenc, field_name):
 
 
 def emit_super_send(mgenc, msg):
-    super_class = mgenc.get_holder().get_super_class()
-    method = super_class.lookup_invokable(msg)
-    if not method:
-        raise Exception("Not yet implemented")
-    idx = mgenc.add_literal_if_absent(method)
+    idx = mgenc.add_literal_if_absent(msg)
     _emit2(mgenc, BC.super_send, idx)
 
 

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -36,6 +36,7 @@ class ParserBase(object):
         self._text     = None
         self._next_sym = Symbol.NONE
         self._get_symbol_from_lexer()
+        self._super_send = False
 
     def classdef(self, cgenc):
         cgenc.set_name(self._universe.symbol_for(self._text))
@@ -79,18 +80,13 @@ class ParserBase(object):
         else:
             super_name = self._universe.symbol_for("Object")
 
-        cgenc.set_super_name(super_name)
-
         # Load the super class, if it is not nil (break the dependency cycle)
         if super_name.get_embedded_string() != "nil":
             super_class = self._universe.load_class(super_name)
             if not super_class:
                 raise ParseError("Super class %s could not be loaded"
                                  % super_name.get_embedded_string(), Symbol.NONE, self)
-            cgenc.set_instance_fields_of_super(
-                super_class.get_instance_fields())
-            cgenc.set_class_fields_of_super(
-                super_class.get_class(self._universe).get_instance_fields())
+            cgenc.set_super_class(super_class)
 
     def _sym_in(self, symbol_list):
         return self._sym in symbol_list

--- a/src/som/interpreter/ast/nodes/dispatch.py
+++ b/src/som/interpreter/ast/nodes/dispatch.py
@@ -123,20 +123,6 @@ class _CachedDnuObjectCheckNode(_AbstractCachedDispatchNode):
             return self._next.execute_dispatch(rcvr, args)
 
 
-class SuperDispatchNode(_AbstractDispatchNode):
-
-    _immutable_fields_ = ['_cached_method']
-
-    def __init__(self, selector, lookup_class, universe):
-        _AbstractDispatchNode.__init__(self, universe)
-        self._cached_method = lookup_class.lookup_invokable(selector)
-        if self._cached_method is None:
-            raise RuntimeError("#dnu support for super missing")
-
-    def execute_dispatch(self, rcvr, args):
-        return self._cached_method.invoke(rcvr, args)
-
-
 # @jit.unroll_safe
 def _prepare_dnu_arguments(arguments, selector, universe):
     # Compute the number of arguments

--- a/src/som/interpreter/ast/nodes/expression_node.py
+++ b/src/som/interpreter/ast/nodes/expression_node.py
@@ -5,6 +5,3 @@ class ExpressionNode(Node):
 
     def __init__(self, source_section):
         Node.__init__(self, source_section)
-
-    def is_super_node(self):
-        return False

--- a/src/som/interpreter/ast/nodes/message/super_node.py
+++ b/src/som/interpreter/ast/nodes/message/super_node.py
@@ -1,0 +1,14 @@
+from .abstract_node import AbstractMessageNode
+
+
+class SuperMessageNode(AbstractMessageNode):
+    def __init__(self, selector, receiver, args, super_class, source_section = None):
+        AbstractMessageNode.__init__(self, selector, None, receiver, args, source_section)
+        method = super_class.lookup_invokable(selector)
+        if not method:
+            raise Exception("Not yet implemented")
+        self._method = method
+
+    def execute(self, frame):
+        rcvr, args = self._evaluate_rcvr_and_args(frame)
+        return self._method.invoke(rcvr, args)

--- a/src/som/interpreter/ast/nodes/message/super_node.py
+++ b/src/som/interpreter/ast/nodes/message/super_node.py
@@ -4,11 +4,16 @@ from .abstract_node import AbstractMessageNode
 class SuperMessageNode(AbstractMessageNode):
     def __init__(self, selector, receiver, args, super_class, source_section = None):
         AbstractMessageNode.__init__(self, selector, None, receiver, args, source_section)
-        method = super_class.lookup_invokable(selector)
-        if not method:
-            raise Exception("Not yet implemented")
-        self._method = method
+        self._method = None
+        self._super_class = super_class
+        self._selector = selector
 
     def execute(self, frame):
+        if self._method is None:
+            method = self._super_class.lookup_invokable(self._selector)
+            if not method:
+                raise Exception("Not yet implemented")
+            self._method = method
+
         rcvr, args = self._evaluate_rcvr_and_args(frame)
         return self._method.invoke(rcvr, args)

--- a/src/som/interpreter/ast/nodes/message/super_node.py
+++ b/src/som/interpreter/ast/nodes/message/super_node.py
@@ -2,6 +2,9 @@ from .abstract_node import AbstractMessageNode
 
 
 class SuperMessageNode(AbstractMessageNode):
+
+    _immutable_fields_ = ['_method?', '_super_class', '_selector']
+
     def __init__(self, selector, receiver, args, super_class, source_section = None):
         AbstractMessageNode.__init__(self, selector, None, receiver, args, source_section)
         self._method = None

--- a/src/som/interpreter/ast/nodes/variable_node.py
+++ b/src/som/interpreter/ast/nodes/variable_node.py
@@ -80,31 +80,6 @@ class NonLocalSelfReadNode(ContextualNode):
         return self.determine_outer_self(frame)
 
 
-class NonLocalSuperReadNode(NonLocalSelfReadNode):
-
-    _immutable_fields_ = ["_super_class_name", "_on_class_side", "_universe"]
-
-    def __init__(self, context_level, super_class_name, on_class_side,
-                 universe, source_section = None):
-        NonLocalSelfReadNode.__init__(self, context_level, source_section)
-        self._super_class_name = super_class_name
-        self._on_class_side    = on_class_side
-        self._universe         = universe
-
-    @jit.elidable_promote('all')
-    def _get_lexical_super_class(self):
-        clazz = self._universe.get_global(self._super_class_name)
-        if self._on_class_side:
-            clazz = clazz.get_class(self._universe)
-        return clazz.get_super_class()
-
-    def is_super_node(self):
-        return True
-
-    def get_super_class(self):
-        return self._get_lexical_super_class()
-
-
 class NonLocalTempWriteNode(_NonLocalVariableNode):
 
     _immutable_fields_ = ['_value_expr?']
@@ -172,34 +147,6 @@ class LocalSelfReadNode(ExpressionNode):
 
     def execute(self, frame):
         return frame.get_self()
-
-
-class LocalSuperReadNode(LocalSelfReadNode):
-
-    _immutable_fields_ = ['_super_class_name', '_on_class_side', '_universe']
-
-    def __init__(self, super_class_name, on_class_side, universe,
-                 source_section):
-        LocalSelfReadNode.__init__(self, source_section)
-        self._super_class_name = super_class_name
-        self._on_class_side    = on_class_side
-        self._universe         = universe
-
-    def is_super_node(self):
-        return True
-
-    @jit.elidable_promote('all')
-    def _get_lexical_super_class(self):
-        clazz = self._universe.get_global(self._super_class_name)
-        if self._on_class_side:
-            clazz = clazz.get_class(self._universe)
-        return clazz.get_super_class()
-
-    def is_super_node(self):
-        return True
-
-    def get_super_class(self):
-        return self._get_lexical_super_class()
 
 
 class LocalArgumentWriteNode(_LocalVariableNode):

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -25,7 +25,9 @@ class Bytecodes(object):
     inc              = 17
     dec              = 18
 
-    _num_bytecodes   = 17
+    q_super_send     = 19
+
+    _num_bytecodes   = 20
 
     _bytecode_length = [ 1, # halt
                          1,  # dup
@@ -46,6 +48,7 @@ class Bytecodes(object):
                          1,  # return_self
                          1,  # inc
                          1,  # dec
+                         2,  # q_super_send
                          ]
 
     _stack_effect_depends_on_message = -1000  # chose a unreasonable number to be recognizable
@@ -69,6 +72,7 @@ class Bytecodes(object):
                                0,                               # return_self
                                0,                               # inc
                                0,                               # dec
+                              _stack_effect_depends_on_message, # q_super_send
                               ]
 
 

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -40,23 +40,19 @@ class Interpreter(object):
 
     def _do_super_send(self, bytecode_index, frame, method):
         # Handle the super send bytecode
-        signature = method.get_constant(bytecode_index)
-
-        # Send the message
-        # Lookup the invokable with the given signature
-        invokable = method.get_holder().get_super_class().lookup_invokable(signature)
+        invokable = method.get_constant(bytecode_index)
 
         if invokable:
             # Invoke the invokable in the current frame
             invokable.invoke(frame, self)
         else:
             # Compute the number of arguments
-            num_args = signature.get_number_of_signature_arguments()
+            num_args = invokable.get_number_of_signature_arguments()
 
             # Compute the receiver
             receiver = frame.get_stack_element(num_args - 1)
 
-            self._send_does_not_understand(receiver, frame, signature)
+            self._send_does_not_understand(receiver, frame, invokable.get_signature())
 
     @jit.unroll_safe
     def _do_return_non_local(self, frame, ctx_level):

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -246,10 +246,10 @@ class Universe(object):
         self._load_system_class(self.nilClass)
         self._load_system_class(self.arrayClass)
         self._load_system_class(self.methodClass)
+        self._load_system_class(self.stringClass)
         self._load_system_class(self.symbolClass)
         self._load_system_class(self.integerClass)
         self._load_system_class(self.primitiveClass)
-        self._load_system_class(self.stringClass)
         self._load_system_class(self.doubleClass)
 
         # Load the generic block class

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -91,6 +91,9 @@ class BcMethod(AbstractObject):
     def get_number_of_arguments(self):
         return self._number_of_arguments
 
+    def get_number_of_signature_arguments(self):
+        return self._number_of_arguments
+
     def get_number_of_bytecodes(self):
         # Get the number of bytecodes in this method
         return len(self._bytecodes)

--- a/src/som/vmobjects/primitive.py
+++ b/src/som/vmobjects/primitive.py
@@ -108,6 +108,9 @@ class _BcPrimitive(_AbstractPrimitive):
         prim_fn = self._prim_fn
         prim_fn(self, frame, interpreter)
 
+    def get_number_of_signature_arguments(self):
+        return self._signature.get_number_of_signature_arguments()
+
 
 class _BcUnaryPrimitive(_AbstractPrimitive):
     _immutable_fields_ = ["_prim_fn"]
@@ -121,6 +124,9 @@ class _BcUnaryPrimitive(_AbstractPrimitive):
         rcvr = frame.top()
         result = prim_fn(rcvr)
         frame.set_top(result)
+
+    def get_number_of_signature_arguments(self):
+        return 1
 
 
 class _BcBinaryPrimitive(_AbstractPrimitive):
@@ -137,6 +143,9 @@ class _BcBinaryPrimitive(_AbstractPrimitive):
         result = prim_fn(rcvr, arg)
         frame.set_top(result)
 
+    def get_number_of_signature_arguments(self):
+        return 2
+
 
 class _BcTernaryPrimitive(_AbstractPrimitive):
     _immutable_fields_ = ["_prim_fn"]
@@ -152,6 +161,9 @@ class _BcTernaryPrimitive(_AbstractPrimitive):
         rcvr = frame.top()
         result = prim_fn(rcvr, arg1, arg2)
         frame.set_top(result)
+
+    def get_number_of_signature_arguments(self):
+        return 3
 
 
 def _empty_invoke(ivkbl, _a, _b):


### PR DESCRIPTION
Previously, super sends where part of the dispatch chain, now, they are separate message send nodes. This matches TruffleSOM.

The bytecode introduces a new `Q_SUPER_SEND` and caches the lookup in the lookup cache array.

Unfortunately, even with lazy lookup, this seems to cost startup performance. Not clear why.

Should be revisited...