### PR TITLE
Remove Interpreter object

### DIFF
--- a/src/som/compiler/bc/disassembler.py
+++ b/src/som/compiler/bc/disassembler.py
@@ -1,4 +1,5 @@
-from som.vm.universe import error_print, error_println, get_current
+from som.vm.current import current_universe
+from som.vm.universe import error_print, error_println
 from som.interpreter.bc.bytecodes import bytecode_as_str, bytecode_length, Bytecodes
 
 
@@ -61,7 +62,7 @@ def dump_method(m, indent):
             constant = m.get_constant(b)
             error_println("(index: " + str(m.get_bytecode(b + 1)) +
                                    ") value: (" +
-                                   str(constant.get_class(get_current()).get_name()) +
+                                   str(constant.get_class(current_universe).get_name()) +
                                    ") " + str(constant))
         elif bytecode == Bytecodes.push_global:
             error_println("(index: " + str(m.get_bytecode(b + 1)) +

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -26,7 +26,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
         num_locals = len(self._locals)
 
         meth = BcMethod(list(self._literals), num_locals, self._compute_stack_depth(),
-                        len(self._bytecode), self._signature)
+                        len(self._bytecode), self._signature, self.universe)
 
         # copy bytecodes into method
         i = 0
@@ -130,7 +130,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
 def create_bootstrap_method(universe):
     """ Create a fake bootstrap method to simplify later frame traversal """
-    bootstrap_method = BcMethod([], 0, 2, 1, universe.symbol_for("bootstrap"))
+    bootstrap_method = BcMethod([], 0, 2, 1, universe.symbol_for("bootstrap"), universe)
 
     bootstrap_method.set_bytecode(0, Bytecodes.halt)
     bootstrap_method.set_holder(universe.systemClass)

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -26,7 +26,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
         num_locals = len(self._locals)
 
         meth = BcMethod(list(self._literals), num_locals, self._compute_stack_depth(),
-                        len(self._bytecode), self._signature, self.universe)
+                        len(self._bytecode), self._signature)
 
         # copy bytecodes into method
         i = 0
@@ -130,7 +130,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
 def create_bootstrap_method(universe):
     """ Create a fake bootstrap method to simplify later frame traversal """
-    bootstrap_method = BcMethod([], 0, 2, 1, universe.symbol_for("bootstrap"), universe)
+    bootstrap_method = BcMethod([], 0, 2, 1, universe.symbol_for("bootstrap"))
 
     bootstrap_method.set_bytecode(0, Bytecodes.halt)
     bootstrap_method.set_holder(universe.systemClass)

--- a/src/som/compiler/class_generation_context.py
+++ b/src/som/compiler/class_generation_context.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from som.vmobjects.array import Array
-from som.vmobjects.primitive import Primitive
+from som.vmobjects.clazz import Class
 
 
 class ClassGenerationContext(object):
@@ -77,7 +77,9 @@ class ClassGenerationContext(object):
         cc_name = self.name.get_embedded_string() + " class"
 
         # Allocate the class of the resulting class
-        result_class = self.universe.new_class(self.universe.metaclassClass)
+        result_class = Class(
+            self.universe.metaclassClass.get_number_of_instance_fields(),
+            self.universe.metaclassClass)
 
         # Initialize the class of the resulting class
         result_class.set_instance_fields(Array.from_objects(
@@ -90,7 +92,7 @@ class ClassGenerationContext(object):
         result_class.set_super_class(super_m_class)
 
         # Allocate the resulting class
-        result = self.universe.new_class(result_class)
+        result = Class(result_class.get_number_of_instance_fields(), result_class)
 
         # Initialize the resulting class
         result.set_name(self.name)

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -116,52 +116,52 @@ def interpret(method, frame):
         next_bc_idx = current_bc_idx + bc_length
 
         # Handle the current bytecode
-        if   bytecode == Bytecodes.halt:                            # BC: 0
+        if   bytecode == Bytecodes.halt:
             return frame.top()
-        elif bytecode == Bytecodes.dup:                             # BC: 1
+        elif bytecode == Bytecodes.dup:
             frame.push(frame.top())
-        elif bytecode == Bytecodes.push_local:                      # BC: 2
+        elif bytecode == Bytecodes.push_local:
             frame.push(
                 frame.get_local(
                     method.get_bytecode(current_bc_idx + 1),
                     method.get_bytecode(current_bc_idx + 2)))
-        elif bytecode == Bytecodes.push_argument:                   # BC: 3
+        elif bytecode == Bytecodes.push_argument:
             frame.push(
                 frame.get_argument(
                     method.get_bytecode(current_bc_idx + 1),
                     method.get_bytecode(current_bc_idx + 2)))
-        elif bytecode == Bytecodes.push_field:                      # BC: 4
+        elif bytecode == Bytecodes.push_field:
             field_index = method.get_bytecode(current_bc_idx + 1)
             ctx_level = method.get_bytecode(current_bc_idx + 2)
             frame.push(get_self(frame, ctx_level).get_field(field_index))
-        elif bytecode == Bytecodes.push_block:                      # BC: 5
+        elif bytecode == Bytecodes.push_block:
             block_method = method.get_constant(current_bc_idx)
             frame.push(BcBlock(block_method, frame))
-        elif bytecode == Bytecodes.push_constant:                   # BC: 6
+        elif bytecode == Bytecodes.push_constant:
             frame.push(method.get_constant(current_bc_idx))
-        elif bytecode == Bytecodes.push_global:                     # BC: 7
+        elif bytecode == Bytecodes.push_global:
             _do_push_global(current_bc_idx, frame, method)
-        elif bytecode == Bytecodes.pop:                             # BC: 8
+        elif bytecode == Bytecodes.pop:
             frame.pop()
-        elif bytecode == Bytecodes.pop_local:                       # BC: 9
+        elif bytecode == Bytecodes.pop_local:
             frame.set_local(
                 method.get_bytecode(current_bc_idx + 1),
                 method.get_bytecode(current_bc_idx + 2),
                 frame.pop())
-        elif bytecode == Bytecodes.pop_argument:                    # BC:10
+        elif bytecode == Bytecodes.pop_argument:
             frame.set_argument(
                 method.get_bytecode(current_bc_idx + 1),
                 method.get_bytecode(current_bc_idx + 2),
                 frame.pop())
-        elif bytecode == Bytecodes.pop_field:                       # BC:11
+        elif bytecode == Bytecodes.pop_field:
             _do_pop_field(current_bc_idx, frame, method)
-        elif bytecode == Bytecodes.send:                            # BC:12
+        elif bytecode == Bytecodes.send:
             _do_send(current_bc_idx, frame, method)
-        elif bytecode == Bytecodes.super_send:                      # BC:13
+        elif bytecode == Bytecodes.super_send:
             _do_super_send(current_bc_idx, frame, method)
-        elif bytecode == Bytecodes.return_local:                    # BC:14
+        elif bytecode == Bytecodes.return_local:
             return frame.top()
-        elif bytecode == Bytecodes.return_non_local:                # BC:15
+        elif bytecode == Bytecodes.return_non_local:
             return _do_return_non_local(
                 frame, method.get_bytecode(current_bc_idx + 1))
         elif bytecode == Bytecodes.return_self:

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -6,284 +6,291 @@ from som.vmobjects.block_bc import BcBlock
 from rlib import jit
 
 
-class Interpreter(object):
+def _do_push_global(bytecode_index, frame, method):
+    # Handle the push global bytecode
+    global_name = method.get_constant(bytecode_index)
 
-    _immutable_fields_ = ["universe"]
+    # Get the global from the universe
+    glob = method.universe.get_global(global_name)
 
-    def __init__(self, universe):
-        self.universe   = universe
+    if glob:
+        # Push the global onto the stack
+        frame.push(glob)
+    else:
+        # Send 'unknownGlobal:' to self
+        _send_unknown_global(get_self_dynamically(frame), frame, global_name, method.universe)
 
-    def _do_push_global(self, bytecode_index, frame, method):
-        # Handle the push global bytecode
-        global_name = method.get_constant(bytecode_index)
 
-        # Get the global from the universe
-        glob = self.universe.get_global(global_name)
+def _do_pop_field(bytecode_index, frame, method):
+    # Handle the pop field bytecode
+    field_index = method.get_bytecode(bytecode_index + 1)
+    ctx_level = method.get_bytecode(bytecode_index + 2)
 
-        if glob:
-            # Push the global onto the stack
-            frame.push(glob)
-        else:
-            # Send 'unknownGlobal:' to self
-            self._send_unknown_global(self.get_self_dynamically(frame), frame, global_name)
+    # Set the field with the computed index to the value popped from the stack
+    get_self(frame, ctx_level).set_field(field_index, frame.pop())
 
-    def _do_pop_field(self, bytecode_index, frame, method):
-        # Handle the pop field bytecode
-        field_index = method.get_bytecode(bytecode_index + 1)
-        ctx_level = method.get_bytecode(bytecode_index + 2)
 
-        # Set the field with the computed index to the value popped from the stack
-        self.get_self(frame, ctx_level).set_field(field_index, frame.pop())
+def _do_super_send(bytecode_index, frame, method):
+    signature = method.get_constant(bytecode_index)
 
-    def _do_super_send(self, bytecode_index, frame, method):
-        signature = method.get_constant(bytecode_index)
+    receiver_class = method.get_holder().get_super_class()
+    invokable = receiver_class.lookup_invokable(signature)
+    method.set_inline_cache(bytecode_index, receiver_class, invokable)
+    method.set_bytecode(bytecode_index, Bytecodes.q_super_send)
 
-        receiver_class = method.get_holder().get_super_class()
-        invokable = receiver_class.lookup_invokable(signature)
-        method.set_inline_cache(bytecode_index, receiver_class, invokable)
-        method.set_bytecode(bytecode_index, Bytecodes.q_super_send)
-
-        if invokable:
-            invokable.invoke(frame, self)
-        else:
-            num_args = invokable.get_number_of_signature_arguments()
-            receiver = frame.get_stack_element(num_args - 1)
-            self._send_does_not_understand(receiver, frame, invokable.get_signature())
-
-    def _do_q_super_send(self, bytecode_index, frame, method):
-        invokable = method.get_inline_cache_invokable(bytecode_index)
-        if invokable:
-            invokable.invoke(frame, self)
-        else:
-            num_args = invokable.get_number_of_signature_arguments()
-            receiver = frame.get_stack_element(num_args - 1)
-            self._send_does_not_understand(receiver, frame, invokable.get_signature())
-
-    @jit.unroll_safe
-    def _do_return_non_local(self, frame, ctx_level):
-        # get result from stack
-        result = frame.top()
-
-        # Compute the context for the non-local return
-        context = frame.get_context_at(ctx_level)
-
-        # Make sure the block context is still on the stack
-        if not context.has_previous_frame():
-            # Try to recover by sending 'escapedBlock:' to the sending object
-            # this can get a bit nasty when using nested blocks. In this case
-            # the "sender" will be the surrounding block and not the object
-            # that actually sent the 'value' message.
-            block  = frame.get_argument(0, 0)
-            sender = frame.get_previous_frame().get_outer_context().get_argument(0, 0)
-
-            # ... and execute the escapedBlock message instead
-            self._send_escaped_block(sender, frame, block)
-            return frame.top()
-
-        raise ReturnException(result, context)
-
-    def _do_send(self, bytecode_index, frame, method):
-        # Handle the send bytecode
-        signature = method.get_constant(bytecode_index)
-
-        # Get the number of arguments from the signature
-        num_args = signature.get_number_of_signature_arguments()
-
-        # Get the receiver from the stack
+    if invokable:
+        invokable.invoke(frame)
+    else:
+        num_args = invokable.get_number_of_signature_arguments()
         receiver = frame.get_stack_element(num_args - 1)
+        _send_does_not_understand(receiver, frame, invokable.get_signature(), method.universe)
 
-        # Send the message
-        self._send(method, frame, signature, receiver.get_class(self.universe),
-                   bytecode_index)
 
-    @jit.unroll_safe
-    def interpret(self, method, frame):
-        current_bc_idx = 0
-        while True:
-            # since methods cannot contain loops (all loops are done via primitives)
-            # profiling only needs to be done on pc = 0
-            if current_bc_idx == 0:
-                jitdriver.can_enter_jit(
-                    bytecode_index=current_bc_idx, interp=self, method=method, frame=frame)
-            jitdriver.jit_merge_point(
-                bytecode_index=current_bc_idx, interp=self, method=method, frame=frame)
+def _do_q_super_send(bytecode_index, frame, method):
+    invokable = method.get_inline_cache_invokable(bytecode_index)
+    if invokable:
+        invokable.invoke(frame)
+    else:
+        num_args = invokable.get_number_of_signature_arguments()
+        receiver = frame.get_stack_element(num_args - 1)
+        _send_does_not_understand(receiver, frame, invokable.get_signature(), method.universe)
 
-            bytecode = method.get_bytecode(current_bc_idx)
 
-            # Get the length of the current bytecode
-            bc_length = bytecode_length(bytecode)
+@jit.unroll_safe
+def _do_return_non_local(frame, ctx_level, universe):
+    # get result from stack
+    result = frame.top()
 
-            # Compute the next bytecode index
-            next_bc_idx = current_bc_idx + bc_length
+    # Compute the context for the non-local return
+    context = frame.get_context_at(ctx_level)
 
-            # Handle the current bytecode
-            if   bytecode == Bytecodes.halt:                            # BC: 0
-                return frame.top()
-            elif bytecode == Bytecodes.dup:                             # BC: 1
-                frame.push(frame.top())
-            elif bytecode == Bytecodes.push_local:                      # BC: 2
-                frame.push(
-                    frame.get_local(
-                        method.get_bytecode(current_bc_idx + 1),
-                        method.get_bytecode(current_bc_idx + 2)))
-            elif bytecode == Bytecodes.push_argument:                   # BC: 3
-                frame.push(
-                    frame.get_argument(
-                        method.get_bytecode(current_bc_idx + 1),
-                        method.get_bytecode(current_bc_idx + 2)))
-            elif bytecode == Bytecodes.push_field:                      # BC: 4
-                field_index = method.get_bytecode(current_bc_idx + 1)
-                ctx_level = method.get_bytecode(current_bc_idx + 2)
-                frame.push(self.get_self(frame, ctx_level).get_field(field_index))
-            elif bytecode == Bytecodes.push_block:                      # BC: 5
-                block_method = method.get_constant(current_bc_idx)
-                frame.push(BcBlock(block_method, frame))
-            elif bytecode == Bytecodes.push_constant:                   # BC: 6
-                frame.push(method.get_constant(current_bc_idx))
-            elif bytecode == Bytecodes.push_global:                     # BC: 7
-                self._do_push_global(current_bc_idx, frame, method)
-            elif bytecode == Bytecodes.pop:                             # BC: 8
-                frame.pop()
-            elif bytecode == Bytecodes.pop_local:                       # BC: 9
-                frame.set_local(
+    # Make sure the block context is still on the stack
+    if not context.has_previous_frame():
+        # Try to recover by sending 'escapedBlock:' to the sending object
+        # this can get a bit nasty when using nested blocks. In this case
+        # the "sender" will be the surrounding block and not the object
+        # that actually sent the 'value' message.
+        block  = frame.get_argument(0, 0)
+        sender = frame.get_previous_frame().get_outer_context().get_argument(0, 0)
+
+        # ... and execute the escapedBlock message instead
+        _send_escaped_block(sender, frame, block, universe)
+        return frame.top()
+
+    raise ReturnException(result, context)
+
+
+def _do_send(bytecode_index, frame, method):
+    # Handle the send bytecode
+    signature = method.get_constant(bytecode_index)
+
+    # Get the number of arguments from the signature
+    num_args = signature.get_number_of_signature_arguments()
+
+    # Get the receiver from the stack
+    receiver = frame.get_stack_element(num_args - 1)
+
+    # Send the message
+    _send(method, frame, signature, receiver.get_class(method.universe),
+          bytecode_index, method.universe)
+
+
+@jit.unroll_safe
+def interpret(method, frame):
+    current_bc_idx = 0
+    while True:
+        # since methods cannot contain loops (all loops are done via primitives)
+        # profiling only needs to be done on pc = 0
+        if current_bc_idx == 0:
+            jitdriver.can_enter_jit(
+                bytecode_index=current_bc_idx, method=method, frame=frame)
+        jitdriver.jit_merge_point(
+            bytecode_index=current_bc_idx, method=method, frame=frame)
+
+        bytecode = method.get_bytecode(current_bc_idx)
+
+        # Get the length of the current bytecode
+        bc_length = bytecode_length(bytecode)
+
+        # Compute the next bytecode index
+        next_bc_idx = current_bc_idx + bc_length
+
+        # Handle the current bytecode
+        if   bytecode == Bytecodes.halt:                            # BC: 0
+            return frame.top()
+        elif bytecode == Bytecodes.dup:                             # BC: 1
+            frame.push(frame.top())
+        elif bytecode == Bytecodes.push_local:                      # BC: 2
+            frame.push(
+                frame.get_local(
                     method.get_bytecode(current_bc_idx + 1),
-                    method.get_bytecode(current_bc_idx + 2),
-                    frame.pop())
-            elif bytecode == Bytecodes.pop_argument:                    # BC:10
-                frame.set_argument(
+                    method.get_bytecode(current_bc_idx + 2)))
+        elif bytecode == Bytecodes.push_argument:                   # BC: 3
+            frame.push(
+                frame.get_argument(
                     method.get_bytecode(current_bc_idx + 1),
-                    method.get_bytecode(current_bc_idx + 2),
-                    frame.pop())
-            elif bytecode == Bytecodes.pop_field:                       # BC:11
-                self._do_pop_field(current_bc_idx, frame, method)
-            elif bytecode == Bytecodes.send:                            # BC:12
-                self._do_send(current_bc_idx, frame, method)
-            elif bytecode == Bytecodes.super_send:                      # BC:13
-                self._do_super_send(current_bc_idx, frame, method)
-            elif bytecode == Bytecodes.return_local:                    # BC:14
-                return frame.top()
-            elif bytecode == Bytecodes.return_non_local:                # BC:15
-                return self._do_return_non_local(frame, method.get_bytecode(current_bc_idx + 1))
-            elif bytecode == Bytecodes.return_self:
-                return frame.get_argument(0, 0)
-            elif bytecode == Bytecodes.inc:
-                val = frame.top()
-                from som.vmobjects.integer import Integer
-                from som.vmobjects.double import Double
-                from som.vmobjects.biginteger import BigInteger
-                if isinstance(val, Integer):
-                    result = val.prim_inc()
-                elif isinstance(val, Double):
-                    result = val.prim_inc()
-                elif isinstance(val, BigInteger):
-                    result = val.prim_inc()
-                else:
-                    return self._not_yet_implemented()
-                frame.set_top(result)
-            elif bytecode == Bytecodes.dec:
-                val = frame.top()
-                from som.vmobjects.integer import Integer
-                from som.vmobjects.double import Double
-                from som.vmobjects.biginteger import BigInteger
-                if isinstance(val, Integer):
-                    result = val.prim_dec()
-                elif isinstance(val, Double):
-                    result = val.prim_dec()
-                elif isinstance(val, BigInteger):
-                    result = val.prim_dec()
-                else:
-                    return self._not_yet_implemented()
-                frame.set_top(result)
-            elif bytecode == Bytecodes.q_super_send:
-                self._do_q_super_send(current_bc_idx, frame, method)
+                    method.get_bytecode(current_bc_idx + 2)))
+        elif bytecode == Bytecodes.push_field:                      # BC: 4
+            field_index = method.get_bytecode(current_bc_idx + 1)
+            ctx_level = method.get_bytecode(current_bc_idx + 2)
+            frame.push(get_self(frame, ctx_level).get_field(field_index))
+        elif bytecode == Bytecodes.push_block:                      # BC: 5
+            block_method = method.get_constant(current_bc_idx)
+            frame.push(BcBlock(block_method, frame))
+        elif bytecode == Bytecodes.push_constant:                   # BC: 6
+            frame.push(method.get_constant(current_bc_idx))
+        elif bytecode == Bytecodes.push_global:                     # BC: 7
+            _do_push_global(current_bc_idx, frame, method)
+        elif bytecode == Bytecodes.pop:                             # BC: 8
+            frame.pop()
+        elif bytecode == Bytecodes.pop_local:                       # BC: 9
+            frame.set_local(
+                method.get_bytecode(current_bc_idx + 1),
+                method.get_bytecode(current_bc_idx + 2),
+                frame.pop())
+        elif bytecode == Bytecodes.pop_argument:                    # BC:10
+            frame.set_argument(
+                method.get_bytecode(current_bc_idx + 1),
+                method.get_bytecode(current_bc_idx + 2),
+                frame.pop())
+        elif bytecode == Bytecodes.pop_field:                       # BC:11
+            _do_pop_field(current_bc_idx, frame, method)
+        elif bytecode == Bytecodes.send:                            # BC:12
+            _do_send(current_bc_idx, frame, method)
+        elif bytecode == Bytecodes.super_send:                      # BC:13
+            _do_super_send(current_bc_idx, frame, method)
+        elif bytecode == Bytecodes.return_local:                    # BC:14
+            return frame.top()
+        elif bytecode == Bytecodes.return_non_local:                # BC:15
+            return _do_return_non_local(
+                frame, method.get_bytecode(current_bc_idx + 1), method.universe)
+        elif bytecode == Bytecodes.return_self:
+            return frame.get_argument(0, 0)
+        elif bytecode == Bytecodes.inc:
+            val = frame.top()
+            from som.vmobjects.integer import Integer
+            from som.vmobjects.double import Double
+            from som.vmobjects.biginteger import BigInteger
+            if isinstance(val, Integer):
+                result = val.prim_inc()
+            elif isinstance(val, Double):
+                result = val.prim_inc()
+            elif isinstance(val, BigInteger):
+                result = val.prim_inc()
             else:
-                self._unknown_bytecode(bytecode)
-
-            current_bc_idx = next_bc_idx
-
-    def _not_yet_implemented(self):
-        raise Exception("Not yet implemented")
-
-    def _unknown_bytecode(self, bytecode):
-        raise Exception("Unknown bytecode: " + str(bytecode))
-
-    @staticmethod
-    def get_self(frame, ctx_level):
-        # Get the self object from the interpreter
-        return frame.get_argument(0, ctx_level)
-
-    @staticmethod
-    def get_self_dynamically(frame):
-        # Get the self object from the interpreter
-        return frame.get_outer_context().get_argument(0, 0)
-
-    def _send(self, m, frame, selector, receiver_class, bytecode_index):
-        # selector.inc_send_count()
-
-        # First try the inline cache
-        cached_class = m.get_inline_cache_class(bytecode_index)
-        if cached_class == receiver_class:
-            invokable = m.get_inline_cache_invokable(bytecode_index)
+                return _not_yet_implemented()
+            frame.set_top(result)
+        elif bytecode == Bytecodes.dec:
+            val = frame.top()
+            from som.vmobjects.integer import Integer
+            from som.vmobjects.double import Double
+            from som.vmobjects.biginteger import BigInteger
+            if isinstance(val, Integer):
+                result = val.prim_dec()
+            elif isinstance(val, Double):
+                result = val.prim_dec()
+            elif isinstance(val, BigInteger):
+                result = val.prim_dec()
+            else:
+                return _not_yet_implemented()
+            frame.set_top(result)
+        elif bytecode == Bytecodes.q_super_send:
+            _do_q_super_send(current_bc_idx, frame, method)
         else:
-            if not cached_class:
-                # Lookup the invokable with the given signature
+            _unknown_bytecode(bytecode)
+
+        current_bc_idx = next_bc_idx
+
+
+def _not_yet_implemented():
+    raise Exception("Not yet implemented")
+
+
+def _unknown_bytecode(bytecode):
+    raise Exception("Unknown bytecode: " + str(bytecode))
+
+
+def get_self(frame, ctx_level):
+    # Get the self object from the interpreter
+    return frame.get_argument(0, ctx_level)
+
+
+def get_self_dynamically(frame):
+    # Get the self object from the interpreter
+    return frame.get_outer_context().get_argument(0, 0)
+
+
+def _send(m, frame, selector, receiver_class, bytecode_index, universe):
+    # selector.inc_send_count()
+
+    # First try the inline cache
+    cached_class = m.get_inline_cache_class(bytecode_index)
+    if cached_class == receiver_class:
+        invokable = m.get_inline_cache_invokable(bytecode_index)
+    else:
+        if not cached_class:
+            # Lookup the invokable with the given signature
+            invokable = receiver_class.lookup_invokable(selector)
+            m.set_inline_cache(bytecode_index, receiver_class, invokable)
+        else:
+            # the bytecode index after the send is used by the selector constant,
+            # and can be used safely as another cache item
+            cached_class = m.get_inline_cache_class(bytecode_index + 1)
+            if cached_class == receiver_class:
+                invokable = m.get_inline_cache_invokable(bytecode_index + 1)
+            else:
                 invokable = receiver_class.lookup_invokable(selector)
-                m.set_inline_cache(bytecode_index, receiver_class, invokable)
-            else:
-                # the bytecode index after the send is used by the selector constant,
-                # and can be used safely as another cache item
-                cached_class = m.get_inline_cache_class(bytecode_index + 1)
-                if cached_class == receiver_class:
-                    invokable = m.get_inline_cache_invokable(bytecode_index + 1)
-                else:
-                    invokable = receiver_class.lookup_invokable(selector)
-                    if not cached_class:
-                        m.set_inline_cache(bytecode_index + 1, receiver_class, invokable)
+                if not cached_class:
+                    m.set_inline_cache(bytecode_index + 1, receiver_class, invokable)
 
-        if invokable:
-            invokable.invoke(frame, self)
-        else:
-            num_args = selector.get_number_of_signature_arguments()
+    if invokable:
+        invokable.invoke(frame)
+    else:
+        num_args = selector.get_number_of_signature_arguments()
 
-            # Compute the receiver
-            receiver = frame.get_stack_element(num_args - 1)
-            self._send_does_not_understand(receiver, frame, selector)
-
-    def _send_does_not_understand(self, receiver, frame, selector):
-        # ignore self
-        number_of_arguments = selector.get_number_of_signature_arguments() - 1
-        arguments_array = Array.from_size(number_of_arguments)
-
-        # Remove all arguments and put them in the freshly allocated array
-        i = number_of_arguments - 1
-        while i >= 0:
-            arguments_array.set_indexable_field(i, frame.pop())
-            i -= 1
-
-        frame.pop()  # pop self from stack
-        args = [selector, arguments_array]
-        self._lookup_and_send(receiver, frame, "doesNotUnderstand:arguments:", args)
-
-    def _send_unknown_global(self, receiver, frame, global_name):
-        arguments = [global_name]
-        self._lookup_and_send(receiver, frame, "unknownGlobal:", arguments)
-
-    def _send_escaped_block(self, receiver, frame, block):
-        arguments = [block]
-        self._lookup_and_send(receiver, frame, "escapedBlock:", arguments)
-
-    def _lookup_and_send(self, receiver, frame, selector_string, arguments):
-        selector = self.universe.symbol_for(selector_string)
-        invokable = receiver.get_class(self.universe).lookup_invokable(selector)
-
-        frame.push(receiver)
-        for arg in arguments:
-            frame.push(arg)
-
-        invokable.invoke(frame, self)
+        # Compute the receiver
+        receiver = frame.get_stack_element(num_args - 1)
+        _send_does_not_understand(receiver, frame, selector, universe)
 
 
-def get_printable_location(bytecode_index, interp, method):
+def _send_does_not_understand(receiver, frame, selector, universe):
+    # ignore self
+    number_of_arguments = selector.get_number_of_signature_arguments() - 1
+    arguments_array = Array.from_size(number_of_arguments)
+
+    # Remove all arguments and put them in the freshly allocated array
+    i = number_of_arguments - 1
+    while i >= 0:
+        arguments_array.set_indexable_field(i, frame.pop())
+        i -= 1
+
+    frame.pop()  # pop self from stack
+    args = [selector, arguments_array]
+    _lookup_and_send(receiver, frame, "doesNotUnderstand:arguments:", args, universe)
+
+
+def _send_unknown_global(receiver, frame, global_name, universe):
+    arguments = [global_name]
+    _lookup_and_send(receiver, frame, "unknownGlobal:", arguments, universe)
+
+
+def _send_escaped_block(receiver, frame, block, universe):
+    arguments = [block]
+    _lookup_and_send(receiver, frame, "escapedBlock:", arguments, universe)
+
+
+def _lookup_and_send(receiver, frame, selector_string, arguments, universe):
+    selector = universe.symbol_for(selector_string)
+    invokable = receiver.get_class(universe).lookup_invokable(selector)
+
+    frame.push(receiver)
+    for arg in arguments:
+        frame.push(arg)
+
+    invokable.invoke(frame)
+
+
+def get_printable_location(bytecode_index, method):
     from som.vmobjects.method_bc import BcMethod
     from som.interpreter.bc.bytecodes import bytecode_as_str
     assert isinstance(method, BcMethod)
@@ -295,7 +302,7 @@ def get_printable_location(bytecode_index, interp, method):
 
 jitdriver = jit.JitDriver(
     name='Interpreter',
-    greens=['bytecode_index', 'interp', 'method'],
+    greens=['bytecode_index', 'method'],
     reds=['frame'],
     # virtualizables=['frame'],
     get_printable_location=get_printable_location,
@@ -307,7 +314,7 @@ jitdriver = jit.JitDriver(
     # the next line says that calls involving this jitdriver should always be
     # inlined once (which means that things like Integer>>< will be inlined
     # into a while loop again, when enabling this drivers).
-    should_unroll_one_iteration = lambda bytecode_index, inter, method: True)
+    should_unroll_one_iteration = lambda bytecode_index, method: True)
 
 
 def jitpolicy(driver):

--- a/src/som/primitives/ast/object_primitives.py
+++ b/src/som/primitives/ast/object_primitives.py
@@ -1,4 +1,5 @@
 from som.primitives.object_primitives import ObjectPrimitivesBase as _Base
+from som.vm.current import current_universe
 from som.vmobjects.integer import Integer
 
 from som.vmobjects.object_with_layout import ObjectWithLayout
@@ -20,7 +21,7 @@ def _object_size(rcvr):
 def _perform(ivkbl, rcvr, args):
     selector = args[0]
 
-    invokable = rcvr.get_class(ivkbl.universe).lookup_invokable(selector)
+    invokable = rcvr.get_class(current_universe).lookup_invokable(selector)
     return invokable.invoke(rcvr, [])
 
 
@@ -33,7 +34,7 @@ def _perform_with_arguments(ivkbl, rcvr, arguments):
     arg_arr  = arguments[1].as_argument_array()
     selector = arguments[0]
 
-    invokable = rcvr.get_class(ivkbl.universe).lookup_invokable(selector)
+    invokable = rcvr.get_class(current_universe).lookup_invokable(selector)
     return invokable.invoke(rcvr, arg_arr)
 
 

--- a/src/som/primitives/bc/array_primitives.py
+++ b/src/som/primitives/bc/array_primitives.py
@@ -2,7 +2,7 @@ from som.primitives.array_primitives import ArrayPrimitivesBase as _Base
 from som.vmobjects.primitive import Primitive
 
 
-def _at_put(ivkbl, frame, interpreter):
+def _at_put(ivkbl, frame):
     value = frame.pop()
     index = frame.pop()
     rcvr  = frame.top()

--- a/src/som/primitives/bc/false_primitives.py
+++ b/src/som/primitives/bc/false_primitives.py
@@ -1,11 +1,11 @@
 from som.primitives.false_primitives import FalsePrimitivesBase as _Base
 
 
-def _or(ivkbl, frame, interpreter):
+def _or(ivkbl, frame):
     block = frame.pop()
     frame.pop()
     block_method = block.get_method()
-    block_method.invoke(frame, interpreter)
+    block_method.invoke(frame)
 
 
 FalsePrimitives = _Base

--- a/src/som/primitives/bc/integer_primitives.py
+++ b/src/som/primitives/bc/integer_primitives.py
@@ -8,7 +8,7 @@ from som.vmobjects.primitive   import Primitive
 from som.vmobjects.block_bc import block_evaluate, BcBlock
 
 
-def get_printable_location(interpreter, block_method):
+def get_printable_location(block_method):
     from som.vmobjects.method_bc import BcMethod
     assert isinstance(block_method, BcMethod)
     return "to:do: [%s>>%s]" % (block_method.get_holder().get_name().get_embedded_string(),
@@ -17,7 +17,7 @@ def get_printable_location(interpreter, block_method):
 
 jitdriver_int = jit.JitDriver(
     name='to:do: with int',
-    greens=['interpreter', 'block_method'],
+    greens=['block_method'],
     reds='auto',
     # virtualizables=['frame'],
     is_recursive=True,
@@ -25,44 +25,42 @@ jitdriver_int = jit.JitDriver(
 
 jitdriver_double = jit.JitDriver(
     name='to:do: with double',
-    greens=['interpreter', 'block_method'],
+    greens=['block_method'],
     reds='auto',
     # virtualizables=['frame'],
     is_recursive=True,
     get_printable_location=get_printable_location)
 
 
-def _to_do_int(i, by_increment, top, frame, context, interpreter, block_method):
+def _to_do_int(i, by_increment, top, frame, context, block_method):
     assert isinstance(i, int)
     assert isinstance(top, int)
     while i <= top:
-        jitdriver_int.jit_merge_point(interpreter=interpreter,
-                                      block_method=block_method)
+        jitdriver_int.jit_merge_point(block_method=block_method)
 
         b = BcBlock(block_method, context)
         frame.push(b)
         frame.push(Integer(i))
-        block_evaluate(b, interpreter, frame)
+        block_evaluate(b, frame)
         frame.pop()
         i += by_increment
 
 
-def _to_do_double(i, by_increment, top, frame, context, interpreter, block_method):
+def _to_do_double(i, by_increment, top, frame, context, block_method):
     assert isinstance(i, int)
     assert isinstance(top, float)
     while i <= top:
-        jitdriver_double.jit_merge_point(interpreter=interpreter,
-                                         block_method=block_method)
+        jitdriver_double.jit_merge_point(block_method=block_method)
 
         b = BcBlock(block_method, context)
         frame.push(b)
         frame.push(Integer(i))
-        block_evaluate(b, interpreter, frame)
+        block_evaluate(b, frame)
         frame.pop()
         i += by_increment
 
 
-def _to_do(ivkbl, frame, interpreter):
+def _to_do(ivkbl, frame):
     block = frame.pop()
     limit = frame.pop()
     self  = frame.pop()  # we do leave it on there
@@ -72,16 +70,14 @@ def _to_do(ivkbl, frame, interpreter):
 
     i = self.get_embedded_integer()
     if isinstance(limit, Double):
-        _to_do_double(i, 1, limit.get_embedded_double(), frame, context, interpreter,
-                      block_method)
+        _to_do_double(i, 1, limit.get_embedded_double(), frame, context, block_method)
     else:
-        _to_do_int(i, 1, limit.get_embedded_integer(), frame, context, interpreter,
-                   block_method)
+        _to_do_int(i, 1, limit.get_embedded_integer(), frame, context, block_method)
 
     frame.push(self)
 
 
-def _to_by_do(ivkbl, frame, interpreter):
+def _to_by_do(ivkbl, frame):
     block = frame.pop()
     by_increment = frame.pop()
     limit = frame.pop()
@@ -92,11 +88,11 @@ def _to_by_do(ivkbl, frame, interpreter):
 
     i = self.get_embedded_integer()
     if isinstance(limit, Double):
-        _to_do_double(i, by_increment.get_embedded_integer(), limit.get_embedded_double(), frame, context, interpreter,
-                      block_method)
+        _to_do_double(i, by_increment.get_embedded_integer(), limit.get_embedded_double(), frame,
+                      context, block_method)
     else:
-        _to_do_int(i, by_increment.get_embedded_integer(), limit.get_embedded_integer(), frame, context, interpreter,
-                   block_method)
+        _to_do_int(i, by_increment.get_embedded_integer(), limit.get_embedded_integer(), frame,
+                   context, block_method)
 
     frame.push(self)
 

--- a/src/som/primitives/bc/object_primitives.py
+++ b/src/som/primitives/bc/object_primitives.py
@@ -1,4 +1,5 @@
 from som.primitives.object_primitives import ObjectPrimitivesBase as _Base
+from som.vm.current import current_universe
 
 from som.vmobjects.object    import Object
 from som.vmobjects.primitive import Primitive, UnaryPrimitive
@@ -21,7 +22,7 @@ def _perform(ivkbl, frame):
     selector = frame.pop()
     rcvr     = frame.top()
 
-    invokable = rcvr.get_class(ivkbl.universe).lookup_invokable(selector)
+    invokable = rcvr.get_class(current_universe).lookup_invokable(selector)
     invokable.invoke(frame)
 
 
@@ -42,7 +43,7 @@ def _perform_with_arguments(ivkbl, frame):
     for i in range(0, args.get_number_of_indexable_fields()):
         frame.push(args.get_indexable_field(i))
 
-    invokable = rcvr.get_class(ivkbl.universe).lookup_invokable(selector)
+    invokable = rcvr.get_class(current_universe).lookup_invokable(selector)
     invokable.invoke(frame)
 
 

--- a/src/som/primitives/bc/object_primitives.py
+++ b/src/som/primitives/bc/object_primitives.py
@@ -17,24 +17,24 @@ def _object_size(rcvr):
     return Integer(size)
 
 
-def _perform(ivkbl, frame, interpreter):
+def _perform(ivkbl, frame):
     selector = frame.pop()
     rcvr     = frame.top()
 
-    invokable = rcvr.get_class(interpreter.universe).lookup_invokable(selector)
-    invokable.invoke(frame, interpreter)
+    invokable = rcvr.get_class(ivkbl.universe).lookup_invokable(selector)
+    invokable.invoke(frame)
 
 
-def _perform_in_superclass(ivkbl, frame, interpreter):
+def _perform_in_superclass(ivkbl, frame):
     clazz    = frame.pop()
     selector = frame.pop()
     # rcvr     = frame.top()
 
     invokable = clazz.lookup_invokable(selector)
-    invokable.invoke(frame, interpreter)
+    invokable.invoke(frame)
 
 
-def _perform_with_arguments(ivkbl, frame, interpreter):
+def _perform_with_arguments(ivkbl, frame):
     args     = frame.pop()
     selector = frame.pop()
     rcvr     = frame.top()
@@ -42,8 +42,8 @@ def _perform_with_arguments(ivkbl, frame, interpreter):
     for i in range(0, args.get_number_of_indexable_fields()):
         frame.push(args.get_indexable_field(i))
 
-    invokable = rcvr.get_class(interpreter.universe).lookup_invokable(selector)
-    invokable.invoke(frame, interpreter)
+    invokable = rcvr.get_class(ivkbl.universe).lookup_invokable(selector)
+    invokable.invoke(frame)
 
 
 class ObjectPrimitives(_Base):

--- a/src/som/primitives/bc/true_primitives.py
+++ b/src/som/primitives/bc/true_primitives.py
@@ -1,11 +1,11 @@
 from som.primitives.true_primitives import TruePrimitivesBase as _Base
 
 
-def _and(ivkbl, frame, interpreter):
+def _and(ivkbl, frame):
     block = frame.pop()
     frame.pop()
     block_method = block.get_method()
-    block_method.invoke(frame, interpreter)
+    block_method.invoke(frame)
 
 
 TruePrimitives = _Base

--- a/src/som/primitives/object_primitives.py
+++ b/src/som/primitives/object_primitives.py
@@ -1,8 +1,8 @@
 from rlib.objectmodel import compute_identity_hash
 from som.primitives.primitives import Primitives
+from som.vm.current import current_universe
 
 from som.vm.globals import trueObject, falseObject
-from som.vm.universe import get_current
 from som.vmobjects.primitive import UnaryPrimitive, BinaryPrimitive, TernaryPrimitive
 
 
@@ -34,7 +34,7 @@ def _halt(rcvr):
 
 
 def _class(rcvr):
-    return rcvr.get_class(get_current())
+    return rcvr.get_class(current_universe)
 
 
 class ObjectPrimitivesBase(Primitives):

--- a/src/som/primitives/string_primitives.py
+++ b/src/som/primitives/string_primitives.py
@@ -1,9 +1,9 @@
 from rlib.objectmodel import compute_hash
 from som.compiler.symbol import Symbol
 from som.primitives.primitives import Primitives
+from som.vm.current import current_universe
 
 from som.vm.globals import trueObject, falseObject
-from som.vm.universe import get_current
 from som.vmobjects.integer import Integer
 from som.vmobjects.primitive import UnaryPrimitive, BinaryPrimitive, TernaryPrimitive
 from som.vmobjects.string import String
@@ -14,7 +14,7 @@ def _concat(rcvr, argument):
 
 
 def _as_symbol(rcvr):
-    return get_current().symbol_for(rcvr.get_embedded_string())
+    return current_universe.symbol_for(rcvr.get_embedded_string())
 
 
 def _length(rcvr):

--- a/src/som/primitives/system_primitives.py
+++ b/src/som/primitives/system_primitives.py
@@ -4,34 +4,35 @@ from rlib import rgc, jit
 from rlib.streamio import open_file_as_stream, readall_from_stream
 
 from som.primitives.primitives import Primitives
+from som.vm.current import current_universe
 from som.vm.globals import nilObject, trueObject, falseObject
-from som.vm.universe import get_current, std_print, std_println, error_print, error_println
+from som.vm.universe import std_print, std_println, error_print, error_println
 from som.vmobjects.primitive import UnaryPrimitive, BinaryPrimitive, TernaryPrimitive
 
 
 def _load(rcvr, arg):
-    result = get_current().load_class(arg)
+    result = current_universe.load_class(arg)
     return result if result else nilObject
 
 
 def _exit(rcvr, error):
-    return get_current().exit(error.get_embedded_integer())
+    return current_universe.exit(error.get_embedded_integer())
 
 
 def _global(rcvr, argument):
-    result = get_current().get_global(argument)
+    result = current_universe.get_global(argument)
     return result if result else nilObject
 
 
 def _has_global(rcvr, arg):
-    if get_current().has_global(arg):
+    if current_universe.has_global(arg):
         return trueObject
     else:
         return falseObject
 
 
 def _global_put(rcvr, argument, value):
-    get_current().set_global(argument, value)
+    current_universe.set_global(argument, value)
     return value
 
 
@@ -57,13 +58,13 @@ def _error_println(rcvr, string):
 
 def _time(rcvr):
     from som.vmobjects.integer import Integer
-    since_start = time.time() - get_current().start_time
+    since_start = time.time() - current_universe.start_time
     return Integer(int(since_start * 1000))
 
 
 def _ticks(rcvr):
     from som.vmobjects.integer import Integer
-    since_start = time.time() - get_current().start_time
+    since_start = time.time() - current_universe.start_time
     return Integer(int(since_start * 1000000))
 
 

--- a/src/som/vm/current.py
+++ b/src/som/vm/current.py
@@ -1,0 +1,6 @@
+def _init():
+    from som.vm.universe import create_universe
+    return create_universe()
+
+
+current_universe = _init()

--- a/src/som/vm/shell.py
+++ b/src/som/vm/shell.py
@@ -57,9 +57,8 @@ class AstShell(_Shell):
 
 class BcShell(_Shell):
 
-    def __init__(self, universe, interpreter, bootstrap_method):
+    def __init__(self, universe, bootstrap_method):
         _Shell.__init__(self, universe)
-        self._interpreter = interpreter
         self._bootstrap_method = bootstrap_method
         # Create a fake bootstrap frame
         self._current_frame = create_frame(None, self._bootstrap_method, None)
@@ -72,6 +71,6 @@ class BcShell(_Shell):
         self._current_frame.push(it)
 
         # Invoke the run method
-        shell_method.invoke(self._current_frame, self._interpreter)
+        shell_method.invoke(self._current_frame)
 
         return self._current_frame.pop()

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -97,6 +97,9 @@ class Universe(object):
         self.start_time      = time.time()  # a float of the time in seconds
         self._object_system_initialized = False
 
+    def reset(self, avoid_exit):
+        self.__init__(avoid_exit)
+
     def exit(self, error_code):
         if self._avoid_exit:
             self._last_exit_code = error_code
@@ -514,14 +517,6 @@ def create_universe(avoid_exit = False):
         return _BCUniverse(avoid_exit)
 
 
-_current = create_universe()
-
-
-def set_current(universe):
-    global _current
-    _current = universe
-
-
 def error_print(msg):
     os.write(2, encode_to_bytes(msg or ""))
 
@@ -540,13 +535,10 @@ def std_println(msg = ""):
 
 def main(args):
     jit.set_param(None, 'trace_limit', 15000)
-    u = _current
+    from som.vm.current import current_universe
+    u = current_universe
     u.interpret(args[1:])
     u.exit(0)
-
-
-def get_current():
-    return _current
 
 
 if __name__ == '__main__':

--- a/src/som/vmobjects/abstract_object.py
+++ b/src/som/vmobjects/abstract_object.py
@@ -11,5 +11,5 @@ class AbstractObject(object):
         return False
 
     def __str__(self):
-        from som.vm.universe import get_current
-        return "a " + self.get_class(get_current()).get_name().get_embedded_string()
+        from som.vm.current import current_universe
+        return "a " + self.get_class(current_universe).get_name().get_embedded_string()

--- a/src/som/vmobjects/block_bc.py
+++ b/src/som/vmobjects/block_bc.py
@@ -50,18 +50,20 @@ def block_evaluation_primitive(num_args, universe):
     return BcBlock.Evaluation(num_args, universe, _invoke)
 
 
-def block_evaluate(block, interpreter, frame):
+def block_evaluate(block, frame):
+    from som.interpreter.bc.interpreter import interpret
+
     context = block.get_context()
     method  = block.get_method()
     new_frame = create_frame(frame, method, context)
     new_frame.copy_arguments_from(frame, method.get_number_of_arguments())
 
-    result = interpreter.interpret(method, new_frame)
+    result = interpret(method, new_frame)
     frame.pop_old_arguments_and_push_result(method, result)
     new_frame.clear_previous_frame()
 
 
-def _invoke(ivkbl, frame, interpreter):
+def _invoke(ivkbl, frame):
     assert isinstance(ivkbl, BcBlock.Evaluation)
     rcvr = frame.get_stack_element(ivkbl._number_of_arguments - 1)
-    block_evaluate(rcvr, interpreter, frame)
+    block_evaluate(rcvr, frame)

--- a/src/som/vmobjects/clazz.py
+++ b/src/som/vmobjects/clazz.py
@@ -16,17 +16,15 @@ class _Class(Object):
                           "_name",
                           "_instance_fields"
                           "_invokables_table",
-                          "has_primitives",
-                          "universe"]
+                          "has_primitives"]
 
-    def __init__(self, universe, number_of_fields=Object.NUMBER_OF_OBJECT_FIELDS, obj_class=None):
+    def __init__(self, number_of_fields=Object.NUMBER_OF_OBJECT_FIELDS, obj_class=None):
         Object.__init__(self, obj_class, number_of_fields)
         self._super_class = nilObject
         self._name        = None
         self._instance_fields = None
         self._invokables_table = None
         self.has_primitives = False
-        self.universe = universe
 
     def get_super_class(self):
         return self._super_class
@@ -143,12 +141,12 @@ class _Class(Object):
             return clazz.has_primitives
         return False
 
-    def load_primitives(self, display_warning):
+    def load_primitives(self, display_warning, universe):
         from som.primitives.known import (primitives_for_class,
                                           PrimitivesNotFound)
         try:
             prims = primitives_for_class(self)
-            prims(self.universe).install_primitives_in(self)
+            prims(universe).install_primitives_in(self)
         except PrimitivesNotFound:
             if display_warning:
                 from som.vm.universe import error_println
@@ -162,8 +160,8 @@ class _Class(Object):
 class _ClassWithLayout(_Class):
     _immutable_fields_ = ["_layout_for_instances?"]
 
-    def __init__(self, universe, number_of_fields=Object.NUMBER_OF_OBJECT_FIELDS, obj_class=None):
-        _Class.__init__(self, universe, number_of_fields, obj_class)
+    def __init__(self, number_of_fields=Object.NUMBER_OF_OBJECT_FIELDS, obj_class=None):
+        _Class.__init__(self, number_of_fields, obj_class)
         if number_of_fields >= 0:
             self._layout_for_instances = ObjectLayout(number_of_fields, self)
         else:

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -21,11 +21,10 @@ class BcMethod(AbstractObject):
                           "_number_of_arguments",
                           "_initial_stack_pointer",
                           "_number_of_frame_elements",
-                          "_holder",
-                          "universe"]
+                          "_holder"]
 
     def __init__(self, literals, num_locals, max_stack_elements,
-                 num_bytecodes, signature, universe):
+                 num_bytecodes, signature):
         AbstractObject.__init__(self)
 
         # Set the number of bytecodes in this method
@@ -44,7 +43,6 @@ class BcMethod(AbstractObject):
                                           + max_stack_elements + 2)
 
         self._holder = None
-        self.universe = universe
 
     @staticmethod
     def is_primitive():

--- a/src/som/vmobjects/primitive.py
+++ b/src/som/vmobjects/primitive.py
@@ -101,9 +101,9 @@ class _BcPrimitive(_AbstractPrimitive):
         _AbstractPrimitive.__init__(self, signature_string, universe, is_empty)
         self._prim_fn = prim_fn
 
-    def invoke(self, frame, interpreter):
+    def invoke(self, frame):
         prim_fn = self._prim_fn
-        prim_fn(self, frame, interpreter)
+        prim_fn(self, frame)
 
     def get_number_of_signature_arguments(self):
         return self._signature.get_number_of_signature_arguments()
@@ -116,7 +116,7 @@ class _BcUnaryPrimitive(_AbstractPrimitive):
         _AbstractPrimitive.__init__(self, signature_string, universe, is_empty)
         self._prim_fn = prim_fn
 
-    def invoke(self, frame, interpreter):
+    def invoke(self, frame):
         prim_fn = self._prim_fn
         rcvr = frame.top()
         result = prim_fn(rcvr)
@@ -133,7 +133,7 @@ class _BcBinaryPrimitive(_AbstractPrimitive):
         _AbstractPrimitive.__init__(self, signature_string, universe, is_empty)
         self._prim_fn = prim_fn
 
-    def invoke(self, frame, interpreter):
+    def invoke(self, frame):
         prim_fn = self._prim_fn
         arg = frame.pop()
         rcvr = frame.top()
@@ -151,7 +151,7 @@ class _BcTernaryPrimitive(_AbstractPrimitive):
         _AbstractPrimitive.__init__(self, signature_string, universe, is_empty)
         self._prim_fn = prim_fn
 
-    def invoke(self, frame, interpreter):
+    def invoke(self, frame):
         prim_fn = self._prim_fn
         arg2 = frame.pop()
         arg1 = frame.pop()
@@ -163,7 +163,7 @@ class _BcTernaryPrimitive(_AbstractPrimitive):
         return 3
 
 
-def _empty_invoke(ivkbl, _a, _b):
+def _empty_invoke(ivkbl, _a = None, _b = None):
     """ Write a warning to the screen """
     print("Warning: undefined primitive #%s called" %
           ivkbl.get_signature().get_embedded_string())

--- a/src/som/vmobjects/primitive.py
+++ b/src/som/vmobjects/primitive.py
@@ -3,7 +3,7 @@ from som.vmobjects.abstract_object import AbstractObject
 
 
 class _AbstractPrimitive(AbstractObject):
-    _immutable_fields_ = ["_is_empty", "_signature", "_holder", "universe"]
+    _immutable_fields_ = ["_is_empty", "_signature", "_holder"]
 
     def __init__(self, signature_string, universe, is_empty=False):
         AbstractObject.__init__(self)
@@ -11,7 +11,6 @@ class _AbstractPrimitive(AbstractObject):
         self._signature = universe.symbol_for(signature_string)
         self._is_empty  = is_empty
         self._holder    = None
-        self.universe   = universe
 
     @staticmethod
     def is_primitive():
@@ -43,7 +42,7 @@ class _AbstractPrimitive(AbstractObject):
             holder = self.get_holder().get_name().get_embedded_string()
         else:
             holder = "nil"
-        return ("Primitive(" + holder + ">>" + str(self.get_signature()) + ")")
+        return "Primitive(" + holder + ">>" + str(self.get_signature()) + ")"
 
 
 class _AstPrimitive(_AbstractPrimitive):

--- a/tests/test_basic_interpreter.py
+++ b/tests/test_basic_interpreter.py
@@ -2,9 +2,7 @@ import os
 import pytest
 
 from som.compiler.parse_error import ParseError
-
-from som.vm.universe import create_universe, set_current
-
+from som.vm.current import current_universe
 from som.vmobjects.clazz   import Class
 from som.vmobjects.double  import Double
 from som.vmobjects.integer import Integer
@@ -102,15 +100,13 @@ from som.vmobjects.symbol  import Symbol
         ("NumberOfTests", "numberOfTests", 65, Integer),
     ])
 def test_basic_interpreter_behavior(test_class, test_selector, expected_result, result_type):
-    u = create_universe()
-    set_current(u)
-
+    current_universe.reset(True)
     core_lib_path = os.path.dirname(os.path.abspath(__file__)) + "/../core-lib/"
-    u.setup_classpath(core_lib_path + "Smalltalk:"
+    current_universe.setup_classpath(core_lib_path + "Smalltalk:"
                       + core_lib_path + "TestSuite/BasicInterpreterTests")
 
     try:
-        actual_result = u.execute_method(test_class, test_selector)
+        actual_result = current_universe.execute_method(test_class, test_selector)
         _assert_equals_som_value(expected_result, actual_result, result_type)
     except ParseError as e:
         # if we expect a ParseError, then all is fine, otherwise re-raise it

--- a/tests/test_som.py
+++ b/tests/test_som.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from som.vm.universe import create_universe, set_current
+from som.vm.current import current_universe
 
 
 @pytest.mark.parametrize("test_name", [
@@ -33,11 +33,11 @@ from som.vm.universe import create_universe, set_current
         "System"        ,
         "Vector"        ])
 def test_som(test_name):
+    current_universe.reset(True)
     core_lib_path = os.path.dirname(os.path.abspath(__file__)) + "/../core-lib/"
     args = ["-cp", core_lib_path + "Smalltalk",
             core_lib_path + "TestSuite/TestHarness.som", test_name]
-    u = create_universe(True)
-    set_current(u)
-    u.interpret(args)
 
-    assert 0 == u.last_exit_code()
+    current_universe.interpret(args)
+
+    assert 0 == current_universe.last_exit_code()


### PR DESCRIPTION
Avoid the interpreter object since it doesn't keep relevant state.
Rely more on the global for universe, to avoid having to pass it everywhere.