### PR TITLE
Added push_block_no_ctx bytecode

### DIFF
--- a/src/som/compiler/ast/method_generation_context.py
+++ b/src/som/compiler/ast/method_generation_context.py
@@ -115,7 +115,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
         return create_read_node(self._get_self_read(), self.get_field_index(field_name))
 
     def get_global_read(self, var_name):
-        return create_global_node(var_name, self.universe, None)
+        return create_global_node(var_name, self.universe, self, None)
 
     def get_object_field_write(self, field_name, exp):
         if not self.has_field(field_name):

--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -75,6 +75,7 @@ class Parser(ParserBase):
             nil_exp = create_global_node(
                 self.universe.sym_nil,
                 self.universe,
+                None,
                 self._get_source_section(coordinate),
             )
             return nil_exp

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -55,6 +55,8 @@ def emit_push_field(mgenc, field_name):
 
 
 def emit_push_global(mgenc, glob):
+    # the block needs to be able to send #unknownGlobal: to self
+    mgenc.mark_self_as_accessed_from_outer_context()
     _emit2(mgenc, BC.push_global, mgenc.find_literal_index(glob))
 
 

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -56,7 +56,8 @@ def emit_push_field(mgenc, field_name):
 
 def emit_push_global(mgenc, glob):
     # the block needs to be able to send #unknownGlobal: to self
-    mgenc.mark_self_as_accessed_from_outer_context()
+    if not mgenc.is_global_known(glob):
+        mgenc.mark_self_as_accessed_from_outer_context()
     _emit2(mgenc, BC.push_global, mgenc.find_literal_index(glob))
 
 

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -33,8 +33,12 @@ def emit_dup(mgenc):
     _emit1(mgenc, BC.dup)
 
 
-def emit_push_block(mgenc, block_method):
-    _emit2(mgenc, BC.push_block, mgenc.find_literal_index(block_method))
+def emit_push_block(mgenc, block_method, with_ctx):
+    _emit2(
+        mgenc,
+        BC.push_block if with_ctx else BC.push_block_no_ctx,
+        mgenc.find_literal_index(block_method),
+    )
 
 
 def emit_push_local(mgenc, idx, ctx):

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -160,11 +160,6 @@ class MethodGenerationContext(MethodGenerationContextBase):
             return 0
         return 1 + self.outer_genc.get_max_context_level()
 
-    def mark_self_as_accessed_from_outer_context(self):
-        if self.outer_genc:
-            self.outer_genc.mark_self_as_accessed_from_outer_context()
-        self._accesses_variables_of_outer_context = True
-
     def add_bytecode(self, bytecode):
         self._bytecode.append(bytecode)
 

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -146,7 +146,7 @@ class Parser(ParserBase):
 
             block_method = bgenc.assemble(None)
             mgenc.add_literal(block_method)
-            emit_push_block(mgenc, block_method)
+            emit_push_block(mgenc, block_method, bgenc.requires_context())
         else:
             self._literal(mgenc)
 

--- a/src/som/compiler/method_generation_context.py
+++ b/src/som/compiler/method_generation_context.py
@@ -92,6 +92,20 @@ class MethodGenerationContextBase(object):
             list(self._locals.values()),
         )
 
+    def is_global_known(self, global_name):
+        glob = global_name.get_embedded_string()
+        return (
+            glob == "true"
+            or glob == "false"
+            or glob == "nil"
+            or self.universe.has_global(global_name)
+        )
+
+    def mark_self_as_accessed_from_outer_context(self):
+        if self.outer_genc:
+            self.outer_genc.mark_self_as_accessed_from_outer_context()
+        self._accesses_variables_of_outer_context = True
+
     def make_catch_non_local_return(self):
         self.throws_non_local_return = True
         ctx = self._mark_outer_contexts_to_require_context_and_get_root_context()

--- a/src/som/interpreter/ast/nodes/global_read_node.py
+++ b/src/som/interpreter/ast/nodes/global_read_node.py
@@ -1,11 +1,11 @@
-from som.interpreter.ast.frame import FRAME_AND_INNER_RCVR_IDX, read_frame
+from som.interpreter.ast.nodes.contextual_node import ContextualNode
 from som.interpreter.send import lookup_and_send_2
 from som.vm.globals import nilObject, trueObject, falseObject
 
 from som.interpreter.ast.nodes.expression_node import ExpressionNode
 
 
-def create_global_node(global_name, universe, source_section):
+def create_global_node(global_name, universe, mgenc, source_section):
     glob = global_name.get_embedded_string()
     if glob == "true":
         return _ConstantGlobalReadNode(trueObject, source_section)
@@ -18,15 +18,19 @@ def create_global_node(global_name, universe, source_section):
     if assoc is not None:
         return _CachedGlobalReadNode(assoc, source_section)
 
-    return _UninitializedGlobalReadNode(global_name, universe, source_section)
+    context_level = mgenc.get_context_level("self")
+    mgenc.mark_self_as_accessed_from_outer_context()
+    return _UninitializedGlobalReadNode(
+        global_name, universe, context_level, source_section
+    )
 
 
-class _UninitializedGlobalReadNode(ExpressionNode):
+class _UninitializedGlobalReadNode(ContextualNode):
 
     _immutable_fields_ = ["_global_name", "universe"]
 
-    def __init__(self, global_name, universe, source_section=None):
-        ExpressionNode.__init__(self, source_section)
+    def __init__(self, global_name, universe, context_level, source_section=None):
+        ContextualNode.__init__(self, context_level, source_section)
         self._global_name = global_name
         self.universe = universe
 
@@ -34,7 +38,7 @@ class _UninitializedGlobalReadNode(ExpressionNode):
         if self.universe.has_global(self._global_name):
             return self._specialize().execute(frame)
         return lookup_and_send_2(
-            read_frame(frame, FRAME_AND_INNER_RCVR_IDX),
+            self.determine_outer_self(frame),
             self._global_name,
             "unknownGlobal:",
         )

--- a/src/som/interpreter/ast/nodes/return_non_local_node.py
+++ b/src/som/interpreter/ast/nodes/return_non_local_node.py
@@ -1,7 +1,5 @@
 from som.interpreter.ast.frame import (
     mark_as_no_longer_on_stack,
-    FRAME_AND_INNER_RCVR_IDX,
-    read_frame,
     get_inner_as_context,
 )
 from som.interpreter.ast.nodes.contextual_node import ContextualNode
@@ -27,8 +25,7 @@ class ReturnNonLocalNode(ContextualNode):
 
         if block.is_outer_on_stack():
             raise ReturnException(result, block.get_on_stack_marker())
-        block = read_frame(frame, FRAME_AND_INNER_RCVR_IDX)
-        outer_self = block.get_from_outer(FRAME_AND_INNER_RCVR_IDX)
+        outer_self = self.determine_outer_self(frame)
         return lookup_and_send_2(outer_self, block, "escapedBlock:")
 
 

--- a/src/som/interpreter/ast/nodes/return_non_local_node.py
+++ b/src/som/interpreter/ast/nodes/return_non_local_node.py
@@ -1,6 +1,8 @@
 from som.interpreter.ast.frame import (
     mark_as_no_longer_on_stack,
     get_inner_as_context,
+    read_frame,
+    FRAME_AND_INNER_RCVR_IDX,
 )
 from som.interpreter.ast.nodes.contextual_node import ContextualNode
 from som.interpreter.ast.nodes.expression_node import ExpressionNode
@@ -26,7 +28,8 @@ class ReturnNonLocalNode(ContextualNode):
         if block.is_outer_on_stack():
             raise ReturnException(result, block.get_on_stack_marker())
         outer_self = self.determine_outer_self(frame)
-        return lookup_and_send_2(outer_self, block, "escapedBlock:")
+        self_block = read_frame(frame, FRAME_AND_INNER_RCVR_IDX)
+        return lookup_and_send_2(outer_self, self_block, "escapedBlock:")
 
 
 class CatchNonLocalReturnNode(ExpressionNode):

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -10,36 +10,37 @@ class Bytecodes(object):
     push_inner = 3
     push_field = 4
     push_block = 5
-    push_constant = 6
-    push_global = 7
-    pop = 8
-    pop_frame = 9
-    pop_inner = 10
-    pop_field = 11
-    send_1 = 12
-    send_2 = 13
-    send_3 = 14
-    send_n = 15
-    super_send = 16
-    return_local = 17
-    return_non_local = 18
-    return_self = 19
+    push_block_no_ctx = 6
+    push_constant = 7
+    push_global = 8
+    pop = 9
+    pop_frame = 10
+    pop_inner = 11
+    pop_field = 12
+    send_1 = 13
+    send_2 = 14
+    send_3 = 15
+    send_n = 16
+    super_send = 17
+    return_local = 18
+    return_non_local = 19
+    return_self = 20
 
-    inc = 20
-    dec = 21
+    inc = 21
+    dec = 22
 
-    q_super_send_1 = 22
-    q_super_send_2 = 23
-    q_super_send_3 = 24
-    q_super_send_n = 25
+    q_super_send_1 = 23
+    q_super_send_2 = 24
+    q_super_send_3 = 25
+    q_super_send_n = 26
 
-    push_local = 26
-    push_argument = 27
-    pop_local = 28
-    pop_argument = 29
+    push_local = 27
+    push_argument = 28
+    pop_local = 29
+    pop_argument = 30
 
 
-_NUM_BYTECODES = 30
+_NUM_BYTECODES = 31
 
 _BYTECODE_LENGTH = [
     1,  # halt
@@ -48,6 +49,7 @@ _BYTECODE_LENGTH = [
     3,  # push_inner
     3,  # push_field
     2,  # push_block
+    2,  # push_block_no_ctx
     2,  # push_constant
     2,  # push_global
     1,  # pop
@@ -85,6 +87,7 @@ _BYTECODE_STACK_EFFECT = [
     1,  # push_inner
     1,  # push_field
     1,  # push_block
+    1,  # push_block_no_ctx
     1,  # push_constant
     1,  # push_global
     -1,  # pop

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -61,9 +61,9 @@ def _do_return_non_local(result, frame, ctx_level):
     if not block.is_outer_on_stack():
         # Try to recover by sending 'escapedBlock:' to the self object.
         # That is the most outer self object, not the blockSelf.
-        block = read_frame(frame, FRAME_AND_INNER_RCVR_IDX)
+        self_block = read_frame(frame, FRAME_AND_INNER_RCVR_IDX)
         outer_self = get_self_dynamically(frame)
-        return lookup_and_send_2(outer_self, block, "escapedBlock:")
+        return lookup_and_send_2(outer_self, self_block, "escapedBlock:")
 
     raise ReturnException(result, block.get_on_stack_marker())
 

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -59,15 +59,11 @@ def _do_return_non_local(result, frame, ctx_level):
 
     # Make sure the block context is still on the stack
     if not block.is_outer_on_stack():
-        # Try to recover by sending 'escapedBlock:' to the sending object
-        # this can get a bit nasty when using nested blocks. In this case
-        # the "sender" will be the surrounding block and not the object
-        # that actually sent the 'value' message.
+        # Try to recover by sending 'escapedBlock:' to the self object.
+        # That is the most outer self object, not the blockSelf.
         block = read_frame(frame, FRAME_AND_INNER_RCVR_IDX)
-        sender = get_self_dynamically(frame)
-
-        # ... and execute the escapedBlock message instead
-        return lookup_and_send_2(sender, block, "escapedBlock:")
+        outer_self = get_self_dynamically(frame)
+        return lookup_and_send_2(outer_self, block, "escapedBlock:")
 
     raise ReturnException(result, block.get_on_stack_marker())
 

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -174,6 +174,11 @@ def interpret(method, frame, max_stack_size):
             stack_ptr += 1
             stack[stack_ptr] = BcBlock(block_method, get_inner_as_context(frame))
 
+        elif bytecode == Bytecodes.push_block_no_ctx:
+            block_method = method.get_constant(current_bc_idx)
+            stack_ptr += 1
+            stack[stack_ptr] = BcBlock(block_method, None)
+
         elif bytecode == Bytecodes.push_constant:
             stack_ptr += 1
             stack[stack_ptr] = method.get_constant(current_bc_idx)

--- a/src/som/vmobjects/block_bc.py
+++ b/src/som/vmobjects/block_bc.py
@@ -28,7 +28,9 @@ class BcBlock(AbstractObject):
 
     def get_from_outer(self, index):
         promote(index)
-        assert 0 <= index < len(self._outer)
+        assert self._outer and 0 <= index < len(self._outer), "No outer in " + str(
+            self._method
+        )
         assert isinstance(self._outer[index], AbstractObject)
         return self._outer[index]
 


### PR DESCRIPTION
This PR adds the `push_block_no_ctx` bytecode, which avoids grabbing the `Inner` bit and pass it on.
Overall, this unfortunately, doesn't seem to be a win. Interpreter performance goes down by 1-2% on the SomSom benchmarks.

Startup seems to suffer even more.

Otherwise, it's not much changes.

This PR also contains semantics fixes, which cause more `Inner` access to be needed.
Specifically, the `#unknownGlobal:` handler is now sent to the correct self, the outer one of the block.
For that purpose, the core lib is updated with tests.