### PR TITLE
Optimize dup-pop-pop sequence and fix missing optimizations for `^ self`

### DIFF
--- a/src/rlib/string_stream.py
+++ b/src/rlib/string_stream.py
@@ -59,3 +59,12 @@ class StringStream(Stream):
         data = self._string[self.pos : end]
         self.pos += len(data)
         return data
+
+    def readline(self):
+        for i in range(self.pos, len(self._string)):
+            if self._string[i] == "\n":
+                return self.read(i - self.pos + 1)
+        if self.pos == 0:
+            self.pos = len(self._string)
+            return self._string
+        return ""

--- a/src/som/compiler/ast/method_generation_context.py
+++ b/src/som/compiler/ast/method_generation_context.py
@@ -11,8 +11,8 @@ from som.vmobjects.method_ast import AstMethod
 
 
 class MethodGenerationContext(MethodGenerationContextBase):
-    def __init__(self, universe, outer=None):
-        MethodGenerationContextBase.__init__(self, universe, outer)
+    def __init__(self, universe, holder, outer):
+        MethodGenerationContextBase.__init__(self, universe, holder, outer)
 
         self._embedded_block_methods = []
 

--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -161,7 +161,7 @@ class Parser(ParserBase):
             bgenc = MethodGenerationContext(self.universe, mgenc)
             bgenc.holder = mgenc.holder
 
-            block_body = self._nested_block(bgenc)
+            block_body = self.nested_block(bgenc)
             block_method = bgenc.assemble(block_body)
             mgenc.add_embedded_block_method(block_method)
 
@@ -320,7 +320,7 @@ class Parser(ParserBase):
         self._expect(Symbol.EndTerm)
         return Array.from_values(literals[:])
 
-    def _nested_block(self, mgenc):
+    def nested_block(self, mgenc):
         self._nested_block_signature(mgenc)
         expressions = self._block_contents(mgenc)
         self._expect(Symbol.EndBlock)

--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -158,8 +158,7 @@ class Parser(ParserBase):
 
         if self._sym == Symbol.NewBlock:
             coordinate = self._lexer.get_source_coordinate()
-            bgenc = MethodGenerationContext(self.universe, mgenc)
-            bgenc.holder = mgenc.holder
+            bgenc = MethodGenerationContext(self.universe, mgenc.holder, mgenc)
 
             block_body = self.nested_block(bgenc)
             block_method = bgenc.assemble(block_body)

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -10,7 +10,8 @@ def emit_dec(mgenc):
 
 
 def emit_pop(mgenc):
-    _emit1(mgenc, BC.pop)
+    if not mgenc.optimize_dup_pop_pop_sequence():
+        _emit1(mgenc, BC.pop)
 
 
 def emit_push_argument(mgenc, idx, ctx):
@@ -18,6 +19,7 @@ def emit_push_argument(mgenc, idx, ctx):
 
 
 def emit_return_self(mgenc):
+    mgenc.optimize_dup_pop_pop_sequence()
     _emit1(mgenc, BC.return_self)
 
 
@@ -157,10 +159,10 @@ def _emit1(mgenc, code):
 
 def _emit2(mgenc, code, idx):
     mgenc.add_bytecode(code)
-    mgenc.add_bytecode(idx)
+    mgenc.add_bytecode_argument(idx)
 
 
 def _emit3(mgenc, code, idx, ctx):
     mgenc.add_bytecode(code)
-    mgenc.add_bytecode(idx)
-    mgenc.add_bytecode(ctx)
+    mgenc.add_bytecode_argument(idx)
+    mgenc.add_bytecode_argument(ctx)

--- a/src/som/compiler/bc/disassembler.py
+++ b/src/som/compiler/bc/disassembler.py
@@ -72,11 +72,14 @@ def dump_bytecode(m, b, indent=""):
             + str(m.get_bytecode(b + 2))
         )
     elif bytecode == Bytecodes.push_field or bytecode == Bytecodes.pop_field:
+        if m.get_holder():
+            field_name = str(
+                m.get_holder().get_instance_field_name(m.get_bytecode(b + 1))
+            )
+        else:
+            field_name = "Holder Not Set"
         error_println(
-            "(index: "
-            + str(m.get_bytecode(b + 1))
-            + ") field: "
-            + str(m.get_holder().get_instance_field_name(m.get_bytecode(b + 1)))
+            "(index: " + str(m.get_bytecode(b + 1)) + ") field: " + field_name
         )
     elif bytecode == Bytecodes.push_block:
         error_print("block: (index: " + str(m.get_bytecode(b + 1)) + ") ")

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -169,6 +169,9 @@ class MethodGenerationContext(MethodGenerationContextBase):
     def find_literal_index(self, lit):
         return self._literals.index(lit)
 
+    def get_bytecodes(self):
+        return self._bytecode
+
 
 class FindVarResult(object):
     def __init__(self, var, context, is_argument):

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -26,6 +26,22 @@ class MethodGenerationContext(MethodGenerationContextBase):
         self._arg_list = []
         self._local_list = []
 
+    def get_number_of_locals(self):
+        return len(self._local_list)
+
+    def get_number_of_bytecodes(self):
+        return len(self._bytecode)
+
+    def get_maximum_number_of_stack_elements(self):
+        """Should not be used on the fast path. Really just hear for the disassembler."""
+        return self._compute_stack_depth()
+
+    def get_bytecode(self, idx):
+        return self._bytecode[idx]
+
+    def get_holder(self):
+        return self.holder
+
     def add_argument(self, arg):
         argument = MethodGenerationContextBase.add_argument(self, arg)
         self._arg_list.append(argument)

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -5,12 +5,16 @@ from som.interpreter.bc.bytecodes import (
     bytecode_stack_effect,
     bytecode_stack_effect_depends_on_send,
     bytecode_length,
+    Bytecodes,
+    POP_X_BYTECODES,
 )
 from som.vmobjects.primitive import empty_primitive
 from som.vmobjects.method_bc import (
     BcMethodNLR,
     BcMethod,
 )
+
+_NUM_LAST_BYTECODES = 4
 
 
 class MethodGenerationContext(MethodGenerationContextBase):
@@ -26,6 +30,8 @@ class MethodGenerationContext(MethodGenerationContextBase):
         self._arg_list = []
         self._local_list = []
 
+        self._last_4_bytecodes = [Bytecodes.invalid] * _NUM_LAST_BYTECODES
+
     def get_number_of_locals(self):
         return len(self._local_list)
 
@@ -40,7 +46,12 @@ class MethodGenerationContext(MethodGenerationContextBase):
         return self._bytecode[idx]
 
     def get_holder(self):
+        assert self.holder
         return self.holder
+
+    def get_constant(self, bytecode_index):
+        # Get the constant associated to a given bytecode index
+        return self._literals[self.get_bytecode(bytecode_index + 1)]
 
     def add_argument(self, arg):
         argument = MethodGenerationContextBase.add_argument(self, arg)
@@ -135,8 +146,39 @@ class MethodGenerationContext(MethodGenerationContextBase):
     def set_finished(self):
         self._finished = True
 
-    def remove_last_bytecode(self):
-        self._bytecode = self._bytecode[:-1]
+    def remove_last_pop_for_block_local_return(self):
+        # self._bytecode = self._bytecode[:-1]
+        if self._last_4_bytecodes[-1] == Bytecodes.pop:
+            del self._bytecode[-1]
+            return
+
+        if (
+            self._last_4_bytecodes[-1] in POP_X_BYTECODES
+            and self._last_4_bytecodes[-2] == Bytecodes.invalid
+        ):
+            # we just removed the DUP and didn't emit the POP using optimizeDupPopPopSequence()
+            # so, to make blocks work, we need to reintroduce the DUP
+            assert (
+                bytecode_length(Bytecodes.pop_field)
+                == bytecode_length(Bytecodes.pop_field)
+                == bytecode_length(Bytecodes.pop_argument)
+            )
+            assert bytecode_length(Bytecodes.pop_field) == 3
+            idx = len(self._bytecode) - 3
+            assert idx >= 0
+            assert self._bytecode[idx] in POP_X_BYTECODES
+            self._bytecode.insert(idx, Bytecodes.dup)
+
+        # TODO:
+        #     } else if (last4Bytecodes[3] == INC_FIELD) {
+        #       // we optimized the sequence to an INC_FIELD, which doesn't modify the stack
+        #       // but since we need the value to return it from the block, we need to push it.
+        #       last4Bytecodes[3] = INC_FIELD_PUSH;
+        #       assert Bytecodes.getBytecodeLength(INC_FIELD) == 3;
+        #       assert Bytecodes.getBytecodeLength(INC_FIELD) == Bytecodes.getBytecodeLength(
+        #           INC_FIELD_PUSH);
+        #       bytecode.set(bytecode.size() - 3, INC_FIELD_PUSH);
+        #     }
 
     def add_literal_if_absent(self, lit):
         if lit in self._literals:
@@ -178,6 +220,13 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
     def add_bytecode(self, bytecode):
         self._bytecode.append(bytecode)
+        self._last_4_bytecodes[0] = self._last_4_bytecodes[1]
+        self._last_4_bytecodes[1] = self._last_4_bytecodes[2]
+        self._last_4_bytecodes[2] = self._last_4_bytecodes[3]
+        self._last_4_bytecodes[3] = bytecode
+
+    def add_bytecode_argument(self, bytecode):
+        self._bytecode.append(bytecode)
 
     def has_bytecode(self):
         return len(self._bytecode) > 0
@@ -187,6 +236,74 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
     def get_bytecodes(self):
         return self._bytecode
+
+    def _last_bytecode_is(self, idx_from_end, candidate):
+        actual = self._last_4_bytecodes[_NUM_LAST_BYTECODES - 1 - idx_from_end]
+        if candidate == actual:
+            return actual
+        return Bytecodes.invalid
+
+    def _last_bytecode_is_one_of(self, idx_from_end, candidates):
+        actual = self._last_4_bytecodes[_NUM_LAST_BYTECODES - 1 - idx_from_end]
+        if actual == Bytecodes.invalid:
+            return Bytecodes.invalid
+
+        for c in candidates:
+            if c == actual:
+                return actual
+
+        return Bytecodes.invalid
+
+    def _get_offset_of_last_bytecode(self, idx_from_end):
+        bc_offset = len(self._bytecode)
+        for i in range(idx_from_end + 1):
+            actual = self._last_4_bytecodes[_NUM_LAST_BYTECODES - 1 - i]
+            if actual == Bytecodes.invalid:
+                raise Exception("The requested bytecode is not valid")
+
+            bc_offset -= bytecode_length(actual)
+        return bc_offset
+
+    def _remove_last_bytecode_at(self, idx_from_end):
+        bc_offset = self._get_offset_of_last_bytecode(idx_from_end)
+        bc_to_be_removed = self._last_4_bytecodes[
+            _NUM_LAST_BYTECODES - 1 - idx_from_end
+        ]
+        bc_length = bytecode_length(bc_to_be_removed)
+
+        assert bc_length > 0
+        assert bc_offset >= 0
+        del self._bytecode[bc_offset : bc_offset + bc_length]
+
+    def _reset_last_bytecode_buffer(self):
+        self._last_4_bytecodes[0] = Bytecodes.invalid
+        self._last_4_bytecodes[1] = Bytecodes.invalid
+        self._last_4_bytecodes[2] = Bytecodes.invalid
+        self._last_4_bytecodes[3] = Bytecodes.invalid
+
+    def optimize_dup_pop_pop_sequence(self):
+        # TODO:
+        # // when we are inlining blocks, this already happened
+        # // and any new opportunities to apply these optimizations are consequently
+        # // at jump targets for blocks, and we can't remove those
+        # if (isCurrentlyInliningBlock):
+        #   return false;
+        dup_candidate = self._last_bytecode_is(1, Bytecodes.dup)
+        if dup_candidate == Bytecodes.invalid:
+            return False
+
+        pop_candidate = self._last_bytecode_is_one_of(0, POP_X_BYTECODES)
+        if pop_candidate == Bytecodes.invalid:
+            return False
+
+        # TODO:
+        # if (POP_FIELD == popCandidate && optimizePushFieldIncDupPopField())
+        #    return true;
+        self._remove_last_bytecode_at(1)  # remove DUP bytecode
+        self._reset_last_bytecode_buffer()  # prevent subsequent optimizations
+        self._last_4_bytecodes[3] = pop_candidate
+
+        return True
 
 
 class FindVarResult(object):

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -14,8 +14,8 @@ from som.vmobjects.method_bc import (
 
 
 class MethodGenerationContext(MethodGenerationContextBase):
-    def __init__(self, universe, outer=None):
-        MethodGenerationContextBase.__init__(self, universe, outer)
+    def __init__(self, universe, holder, outer):
+        MethodGenerationContextBase.__init__(self, universe, holder, outer)
 
         self._literals = []
         self._finished = False

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -53,11 +53,12 @@ class Parser(ParserBase):
                 # a POP has been generated which must be elided (blocks always
                 # return the value of the last expression, regardless of
                 # whether it was terminated with a . or not)
-                mgenc.remove_last_bytecode()
+                mgenc.remove_last_pop_for_block_local_return()
 
             # if this block is empty, we need to return nil
             if mgenc.is_block_method and not mgenc.has_bytecode():
                 from som.vm.globals import nilObject
+
                 emit_push_constant(mgenc, nilObject)
 
             emit_return_local(mgenc)
@@ -346,6 +347,7 @@ class Parser(ParserBase):
         if not mgenc.is_finished():
             if not mgenc.has_bytecode():
                 from som.vm.globals import nilObject
+
                 emit_push_constant(mgenc, nilObject)
             emit_return_local(mgenc)
             mgenc.set_finished()

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -57,9 +57,8 @@ class Parser(ParserBase):
 
             # if this block is empty, we need to return nil
             if mgenc.is_block_method and not mgenc.has_bytecode():
-                nil_sym = self.universe.symbol_for("nil")
-                mgenc.add_literal_if_absent(nil_sym)
-                emit_push_global(mgenc, nil_sym)
+                from som.vm.globals import nilObject
+                emit_push_constant(mgenc, nilObject)
 
             emit_return_local(mgenc)
             mgenc.set_finished()
@@ -346,9 +345,8 @@ class Parser(ParserBase):
         # a return
         if not mgenc.is_finished():
             if not mgenc.has_bytecode():
-                nil_sym = self.universe.sym_nil
-                mgenc.add_literal_if_absent(nil_sym)
-                emit_push_global(mgenc, nil_sym)
+                from som.vm.globals import nilObject
+                emit_push_constant(mgenc, nilObject)
             emit_return_local(mgenc)
             mgenc.set_finished()
 

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -155,9 +155,7 @@ class Parser(ParserBase):
         elif self._sym == Symbol.NewTerm:
             self._nested_term(mgenc)
         elif self._sym == Symbol.NewBlock:
-            bgenc = MethodGenerationContext(self.universe, mgenc)
-            bgenc.holder = mgenc.holder
-
+            bgenc = MethodGenerationContext(self.universe, mgenc.holder, mgenc)
             self.nested_block(bgenc)
 
             block_method = bgenc.assemble(None)

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -158,7 +158,7 @@ class Parser(ParserBase):
             bgenc = MethodGenerationContext(self.universe, mgenc)
             bgenc.holder = mgenc.holder
 
-            self._nested_block(bgenc)
+            self.nested_block(bgenc)
 
             block_method = bgenc.assemble(None)
             mgenc.add_literal(block_method)
@@ -339,7 +339,7 @@ class Parser(ParserBase):
         )
         self._expect(Symbol.EndTerm)
 
-    def _nested_block(self, mgenc):
+    def nested_block(self, mgenc):
         self._nested_block_signature(mgenc)
         self._block_contents(mgenc)
 

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -76,6 +76,22 @@ class Parser(ParserBase):
                 self._block_body(mgenc, True)
 
     def _result(self, mgenc):
+        # try to parse a `^ self` to emit RETURN_SELF
+        if (
+            not mgenc.is_block_method
+            and self._sym == Symbol.Identifier
+            and self._text == "self"
+        ):
+            self._peek_for_next_symbol_from_lexer_if_necessary()
+            if self._next_sym == Symbol.Period or self._next_sym == Symbol.EndTerm:
+                self._expect(Symbol.Identifier)
+
+                emit_return_self(mgenc)
+                mgenc.set_finished()
+
+                self._accept(Symbol.Period)
+                return
+
         self._expression(mgenc)
         self._accept(Symbol.Period)
 

--- a/src/som/compiler/class_generation_context.py
+++ b/src/som/compiler/class_generation_context.py
@@ -63,7 +63,7 @@ class ClassGenerationContext(object):
     def add_instance_field(self, field):
         self._instance_fields.append(field)
 
-    def get_instance_field_name(self, _idx):
+    def get_instance_field_name(self, _idx):  # pylint: disable=no-self-use
         return "not yet implemented"
         # TODO: return self._instance_fields[idx] and support of super classes, I think
 

--- a/src/som/compiler/class_generation_context.py
+++ b/src/som/compiler/class_generation_context.py
@@ -63,6 +63,9 @@ class ClassGenerationContext(object):
     def add_instance_field(self, field):
         self._instance_fields.append(field)
 
+    def get_instance_field_name(self, idx):
+        return self._instance_fields[idx]
+
     def add_class_field(self, field):
         self._class_fields.append(field)
 

--- a/src/som/compiler/class_generation_context.py
+++ b/src/som/compiler/class_generation_context.py
@@ -63,8 +63,9 @@ class ClassGenerationContext(object):
     def add_instance_field(self, field):
         self._instance_fields.append(field)
 
-    def get_instance_field_name(self, idx):
-        return self._instance_fields[idx]
+    def get_instance_field_name(self, _idx):
+        return "not yet implemented"
+        # TODO: return self._instance_fields[idx] and support of super classes, I think
 
     def add_class_field(self, field):
         self._class_fields.append(field)

--- a/src/som/compiler/method_generation_context.py
+++ b/src/som/compiler/method_generation_context.py
@@ -6,8 +6,9 @@ from som.interpreter.ast.frame import ARG_OFFSET, FRAME_AND_INNER_RCVR_IDX
 
 
 class MethodGenerationContextBase(object):
-    def __init__(self, universe, outer):
-        self.holder = None
+    def __init__(self, universe, holder, outer):
+        self.holder = holder
+        assert holder
         self._arguments = OrderedDict()
         self._locals = OrderedDict()
         self.outer_genc = outer

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -81,8 +81,7 @@ class ParserBase(object):
             or self._sym == Symbol.OperatorSequence
             or self._sym_in(self._binary_op_syms)
         ):
-            mgenc = MethodGenerationContext(self.universe)
-            mgenc.holder = cgenc
+            mgenc = MethodGenerationContext(self.universe, cgenc, None)
             mgenc.add_argument("self")
 
             cgenc.add_instance_method(mgenc.assemble(self.method(mgenc)))
@@ -97,8 +96,7 @@ class ParserBase(object):
                 or self._sym == Symbol.OperatorSequence
                 or self._sym_in(self._binary_op_syms)
             ):
-                mgenc = MethodGenerationContext(self.universe)
-                mgenc.holder = cgenc
+                mgenc = MethodGenerationContext(self.universe, cgenc, None)
                 mgenc.add_argument("self")
 
                 cgenc.add_class_method(mgenc.assemble(self.method(mgenc)))

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -85,7 +85,7 @@ class ParserBase(object):
             mgenc.holder = cgenc
             mgenc.add_argument("self")
 
-            cgenc.add_instance_method(mgenc.assemble(self._method(mgenc)))
+            cgenc.add_instance_method(mgenc.assemble(self.method(mgenc)))
 
         if self._accept(Symbol.Separator):
             cgenc.switch_to_class_side()
@@ -101,7 +101,7 @@ class ParserBase(object):
                 mgenc.holder = cgenc
                 mgenc.add_argument("self")
 
-                cgenc.add_class_method(mgenc.assemble(self._method(mgenc)))
+                cgenc.add_class_method(mgenc.assemble(self.method(mgenc)))
 
         self._expect(Symbol.EndTerm)
 
@@ -346,7 +346,7 @@ class ParserBase(object):
             self._accept(Symbol.Colon)
             mgenc.add_argument_if_absent(self._argument())
 
-    def _method(self, mgenc):
+    def method(self, mgenc):
         self._pattern(mgenc)
         self._expect(Symbol.Equal)
         if self._sym == Symbol.Primitive:

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -243,7 +243,7 @@ class ParserBase(object):
         return self._identifier()
 
     def _expression(self, mgenc):
-        self._peek_for_next_symbol_from_lexer()
+        self._peek_for_next_symbol_from_lexer_if_necessary()
 
         if self._next_sym == Symbol.Assign:
             return self._assignation(mgenc)

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -75,8 +75,12 @@ class Bytecodes(object):
     pop_local = push_argument + 1
     pop_argument = pop_local + 1
 
+    invalid = pop_argument + 1
+
 
 _NUM_BYTECODES = Bytecodes.pop_argument + 1
+
+POP_X_BYTECODES = [Bytecodes.pop_local, Bytecodes.pop_argument, Bytecodes.pop_field]
 
 _BYTECODE_LENGTH = [
     1,  # halt

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -103,11 +103,11 @@ class BytecodeBlockGenerationTest(BytecodeGenerationTest):
     def setUp(self):
         self.cgenc = ClassGenerationContext(current_universe)
         self.method_mgenc = MethodGenerationContext(current_universe, self.cgenc, None)
-        self.method_mgenc.holder = self.cgenc
         self.method_mgenc.add_argument("self")
 
-        self.mgenc = MethodGenerationContext(current_universe, self.cgenc, self.method_mgenc)
-        self.mgenc.holder = self.cgenc
+        self.mgenc = MethodGenerationContext(
+            current_universe, self.cgenc, self.method_mgenc
+        )
         self.mgenc.add_argument("$blockSelf")
 
     def parse_to_bytecodes(self, source):

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -12,6 +12,10 @@ from som.vm.current import current_universe
 
 
 class BytecodeGenerationTest(TestCase):
+    def setUp(self):
+        self.cgenc = None
+        self.mgenc = None
+
     def add_field(self, name):
         self.cgenc.add_instance_field(current_universe.symbol_for(name))
 
@@ -48,28 +52,27 @@ class BytecodeMethodGenerationTest(BytecodeGenerationTest):
 
     def test_dup_pop_argument_pop(self):
         bytecodes = self.parse_to_bytecodes("test: arg = ( arg := 1. ^ self )")
-        self.assertEqual(7, len(bytecodes))
+
+        self.assertEqual(5, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_argument, bytecodes[2])
-        self.assertEqual(Bytecodes.pop, bytecodes[5])
+        self.assertEqual(Bytecodes.pop_argument, bytecodes[1])
+        self.assertEqual(Bytecodes.return_self, bytecodes[4])
 
     def test_dup_pop_argument_pop_implicit_return_self(self):
         bytecodes = self.parse_to_bytecodes("test: arg = ( arg := 1 )")
-        self.assertEqual(7, len(bytecodes))
+
+        self.assertEqual(5, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_argument, bytecodes[2])
-        self.assertEqual(Bytecodes.pop, bytecodes[5])
+        self.assertEqual(Bytecodes.pop_argument, bytecodes[1])
+        self.assertEqual(Bytecodes.return_self, bytecodes[4])
 
     def test_dup_pop_local_pop(self):
         bytecodes = self.parse_to_bytecodes("test = ( | local | local := 1. ^ self )")
 
-        self.assertEqual(7, len(bytecodes))
+        self.assertEqual(5, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_local, bytecodes[2])
-        self.assertEqual(Bytecodes.pop, bytecodes[5])
+        self.assertEqual(Bytecodes.pop_local, bytecodes[1])
+        self.assertEqual(Bytecodes.return_self, bytecodes[4])
 
     def test_dup_pop_field_0_pop(self):
         self.add_field("field")
@@ -89,11 +92,10 @@ class BytecodeMethodGenerationTest(BytecodeGenerationTest):
         self.add_field("field")
         bytecodes = self.parse_to_bytecodes("test = ( field := 1. ^ self )")
 
-        self.assertEqual(7, len(bytecodes))
+        self.assertEqual(5, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_field, bytecodes[2])
-        self.assertEqual(Bytecodes.pop, bytecodes[5])
+        self.assertEqual(Bytecodes.pop_field, bytecodes[1])
+        self.assertEqual(Bytecodes.return_self, bytecodes[4])
 
 
 @pytest.mark.skipif(
@@ -118,17 +120,24 @@ class BytecodeBlockGenerationTest(BytecodeGenerationTest):
 
     def test_block_dup_pop_argument_pop(self):
         bytecodes = self.parse_to_bytecodes("[:arg | arg := 1. arg ]")
-        self.dump()
-        self.assertEqual(10, len(bytecodes))
+
+        self.assertEqual(8, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_argument, bytecodes[2])
-        self.assertEqual(Bytecodes.pop, bytecodes[5])
-        self.assertEqual(Bytecodes.push_argument, bytecodes[6])
-        self.assertEqual(Bytecodes.return_local, bytecodes[9])
+        self.assertEqual(Bytecodes.pop_argument, bytecodes[1])
+        self.assertEqual(Bytecodes.push_argument, bytecodes[4])
+        self.assertEqual(Bytecodes.return_local, bytecodes[7])
 
     def test_block_dup_pop_argument_pop_implicit_return_self(self):
         bytecodes = self.parse_to_bytecodes("[:arg | arg := 1 ]")
+
+        self.assertEqual(6, len(bytecodes))
+        self.assertEqual(Bytecodes.push_1, bytecodes[0])
+        self.assertEqual(Bytecodes.dup, bytecodes[1])
+        self.assertEqual(Bytecodes.pop_argument, bytecodes[2])
+        self.assertEqual(Bytecodes.return_local, bytecodes[5])
+
+    def test_block_dup_pop_argument_pop_implicit_return_self_dot(self):
+        bytecodes = self.parse_to_bytecodes("[:arg | arg := 1. ]")
 
         self.assertEqual(6, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
@@ -148,6 +157,16 @@ class BytecodeBlockGenerationTest(BytecodeGenerationTest):
     def test_block_dup_pop_field_return_local(self):
         self.add_field("field")
         bytecodes = self.parse_to_bytecodes("[ field := 1 ]")
+
+        self.assertEqual(6, len(bytecodes))
+        self.assertEqual(Bytecodes.push_1, bytecodes[0])
+        self.assertEqual(Bytecodes.dup, bytecodes[1])
+        self.assertEqual(Bytecodes.pop_field, bytecodes[2])
+        self.assertEqual(Bytecodes.return_local, bytecodes[5])
+
+    def test_block_dup_pop_field_return_local_dot(self):
+        self.add_field("field")
+        bytecodes = self.parse_to_bytecodes("[ field := 1. ]")
 
         self.assertEqual(6, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -1,6 +1,6 @@
+from unittest import TestCase
 import pytest
 from rlib.string_stream import StringStream
-from unittest import TestCase
 
 from som.compiler.bc.disassembler import dump_method
 from som.compiler.bc.method_generation_context import MethodGenerationContext
@@ -11,9 +11,10 @@ from som.interpreter.bc.bytecodes import Bytecodes
 from som.vm.current import current_universe
 
 
-@pytest.mark.skipif(is_ast_interpreter(), reason="Tests are specific to bytecode interpreter")
+@pytest.mark.skipif(
+    is_ast_interpreter(), reason="Tests are specific to bytecode interpreter"
+)
 class BytecodeGenerationTest(TestCase):
-
     def setUp(self):
         self.cgenc = ClassGenerationContext(current_universe)
         self.mgenc = MethodGenerationContext(current_universe)
@@ -22,6 +23,9 @@ class BytecodeGenerationTest(TestCase):
 
     def add_field(self, name):
         self.cgenc.add_instance_field(current_universe.symbol_for(name))
+
+    def dump(self):
+        dump_method(self.mgenc, "")
 
     def parse_to_bytecodes(self, source):
         parser = Parser(StringStream(source), "test", current_universe)
@@ -43,7 +47,7 @@ class BytecodeGenerationTest(TestCase):
 
     def test_dup_pop_argument_pop(self):
         bytecodes = self.parse_to_bytecodes("test: arg = ( arg := 1. ^ self )")
-        self.assertEqual(10, len(bytecodes))
+        self.assertEqual(7, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
         self.assertEqual(Bytecodes.dup, bytecodes[1])
         self.assertEqual(Bytecodes.pop_argument, bytecodes[2])
@@ -52,7 +56,7 @@ class BytecodeGenerationTest(TestCase):
     def test_dup_pop_local_pop(self):
         bytecodes = self.parse_to_bytecodes("test = ( | local | local := 1. ^ self )")
 
-        self.assertEqual(10, len(bytecodes))
+        self.assertEqual(7, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
         self.assertEqual(Bytecodes.dup, bytecodes[1])
         self.assertEqual(Bytecodes.pop_local, bytecodes[2])
@@ -62,8 +66,7 @@ class BytecodeGenerationTest(TestCase):
         self.add_field("field")
         bytecodes = self.parse_to_bytecodes("test = ( field := 1. ^ self )")
 
-        dump_method(self.mgenc, "")
-        self.assertEqual(8, len(bytecodes))
+        self.assertEqual(5, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
         self.assertEqual(Bytecodes.dup, bytecodes[1])
         self.assertEqual(Bytecodes.pop_field_0, bytecodes[2])
@@ -77,10 +80,8 @@ class BytecodeGenerationTest(TestCase):
         self.add_field("field")
         bytecodes = self.parse_to_bytecodes("test = ( field := 1. ^ self )")
 
-        dump_method(self.mgenc, "")
-        self.assertEqual(10, len(bytecodes))
+        self.assertEqual(7, len(bytecodes))
         self.assertEqual(Bytecodes.push_1, bytecodes[0])
         self.assertEqual(Bytecodes.dup, bytecodes[1])
         self.assertEqual(Bytecodes.pop_field, bytecodes[2])
         self.assertEqual(Bytecodes.pop, bytecodes[5])
-

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -1,0 +1,29 @@
+import pytest
+from rlib.string_stream import StringStream
+from unittest import TestCase
+
+from som.compiler.bc.method_generation_context import MethodGenerationContext
+from som.compiler.bc.parser import Parser
+from som.compiler.class_generation_context import ClassGenerationContext
+from som.interp_type import is_ast_interpreter
+from som.interpreter.bc.bytecodes import Bytecodes
+from som.vm.current import current_universe
+
+
+@pytest.mark.skipif(is_ast_interpreter(), reason="Tests are specific to bytecode interpreter")
+class BytecodeGenerationTest(TestCase):
+    def test_empty_method_returns_self(self):
+        source = """test = ( )"""
+        parser = Parser(StringStream(source), "test", current_universe)
+
+        cgenc = ClassGenerationContext(current_universe)
+        mgenc = MethodGenerationContext(current_universe)
+        mgenc.holder = cgenc
+        mgenc.add_argument("self")
+
+        parser.method(mgenc)
+
+        bytecodes = mgenc.get_bytecodes()
+
+        self.assertEqual(1, len(bytecodes))
+        self.assertEqual(Bytecodes.return_self, bytecodes[0])

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -35,6 +35,12 @@ class BytecodeGenerationTest(TestCase):
         self.assertEqual(1, len(bytecodes))
         self.assertEqual(Bytecodes.return_self, bytecodes[0])
 
+    def test_explicit_return_self(self):
+        bytecodes = self.parse_to_bytecodes("test = ( ^ self )")
+
+        self.assertEqual(1, len(bytecodes))
+        self.assertEqual(Bytecodes.return_self, bytecodes[0])
+
     def test_dup_pop_argument_pop(self):
         bytecodes = self.parse_to_bytecodes("test: arg = ( arg := 1. ^ self )")
         self.assertEqual(10, len(bytecodes))

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -25,8 +25,7 @@ class BytecodeGenerationTest(TestCase):
 class BytecodeMethodGenerationTest(BytecodeGenerationTest):
     def setUp(self):
         self.cgenc = ClassGenerationContext(current_universe)
-        self.mgenc = MethodGenerationContext(current_universe)
-        self.mgenc.holder = self.cgenc
+        self.mgenc = MethodGenerationContext(current_universe, self.cgenc, None)
         self.mgenc.add_argument("self")
 
     def parse_to_bytecodes(self, source):
@@ -103,11 +102,11 @@ class BytecodeMethodGenerationTest(BytecodeGenerationTest):
 class BytecodeBlockGenerationTest(BytecodeGenerationTest):
     def setUp(self):
         self.cgenc = ClassGenerationContext(current_universe)
-        self.method_mgenc = MethodGenerationContext(current_universe)
+        self.method_mgenc = MethodGenerationContext(current_universe, self.cgenc, None)
         self.method_mgenc.holder = self.cgenc
         self.method_mgenc.add_argument("self")
 
-        self.mgenc = MethodGenerationContext(current_universe, self.method_mgenc)
+        self.mgenc = MethodGenerationContext(current_universe, self.cgenc, self.method_mgenc)
         self.mgenc.holder = self.cgenc
         self.mgenc.add_argument("$blockSelf")
 


### PR DESCRIPTION
One of the very common sequences in the bytecode interpreter is the conservative `DUP` `POP_*` `POP` sequence generated for assignments.

Optimizing this is relatively straightforward. The complication is the variable-length bytecodes.
The implemented solution tracks the last 4 bytecodes to be able to determine their length.

I also previously missed some places whether `^ self` wasn't actually using the `RETURN_SELF` bytecode, which is now fixed.

With the expected rising complexity, especially for future inlining optimizations, I actually added tests this time.

There are a few places where code results in `push global nil` being generated. I converted those to `push constant nil`.
This might be incorrect though. Not sure why this happens in TruffleSOM.