### PR TITLE
Fix some mist cases for the optimization to remove dup (pop) pop sequences

### DIFF
--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -300,8 +300,12 @@ class MethodGenerationContext(MethodGenerationContextBase):
         # if (POP_FIELD == popCandidate && optimizePushFieldIncDupPopField())
         #    return true;
         self._remove_last_bytecode_at(1)  # remove DUP bytecode
-        self._reset_last_bytecode_buffer()  # prevent subsequent optimizations
-        self._last_4_bytecodes[3] = pop_candidate
+
+        # adapt last 4 bytecodes
+        assert self._last_4_bytecodes[3] == pop_candidate
+        self._last_4_bytecodes[2] = self._last_4_bytecodes[1]
+        self._last_4_bytecodes[1] = self._last_4_bytecodes[0]
+        self._last_4_bytecodes[0] = Bytecodes.invalid
 
         return True
 

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -147,27 +147,24 @@ class MethodGenerationContext(MethodGenerationContextBase):
         self._finished = True
 
     def remove_last_pop_for_block_local_return(self):
-        # self._bytecode = self._bytecode[:-1]
-        if self._last_4_bytecodes[-1] == Bytecodes.pop:
+        if self._last_4_bytecodes[3] == Bytecodes.pop:
             del self._bytecode[-1]
             return
 
         if (
-            self._last_4_bytecodes[-1] in POP_X_BYTECODES
-            and self._last_4_bytecodes[-2] == Bytecodes.invalid
+            self._last_4_bytecodes[3] in POP_X_BYTECODES
+            and self._last_4_bytecodes[2] != Bytecodes.dup
         ):
             # we just removed the DUP and didn't emit the POP using optimizeDupPopPopSequence()
             # so, to make blocks work, we need to reintroduce the DUP
-            assert (
-                bytecode_length(Bytecodes.pop_field)
-                == bytecode_length(Bytecodes.pop_field)
-                == bytecode_length(Bytecodes.pop_argument)
-            )
-            assert bytecode_length(Bytecodes.pop_field) == 3
-            idx = len(self._bytecode) - 3
+            idx = len(self._bytecode) - bytecode_length(self._last_4_bytecodes[3])
             assert idx >= 0
             assert self._bytecode[idx] in POP_X_BYTECODES
             self._bytecode.insert(idx, Bytecodes.dup)
+
+            self._last_4_bytecodes[0] = self._last_4_bytecodes[1]
+            self._last_4_bytecodes[1] = self._last_4_bytecodes[2]
+            self._last_4_bytecodes[2] = Bytecodes.dup
 
         # TODO:
         #     } else if (last4Bytecodes[3] == INC_FIELD) {

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -80,7 +80,13 @@ class Bytecodes(object):
 
 _NUM_BYTECODES = Bytecodes.pop_argument + 1
 
-POP_X_BYTECODES = [Bytecodes.pop_local, Bytecodes.pop_argument, Bytecodes.pop_field]
+POP_X_BYTECODES = [
+    Bytecodes.pop_local,
+    Bytecodes.pop_argument,
+    Bytecodes.pop_field,
+    Bytecodes.pop_field_0,
+    Bytecodes.pop_field_1,
+]
 
 _BYTECODE_LENGTH = [
     1,  # halt

--- a/src/som/vmobjects/method_ast.py
+++ b/src/som/vmobjects/method_ast.py
@@ -129,7 +129,7 @@ class AstMethod(AbstractMethod):
 
     @jit.elidable_promote("all")
     def get_number_of_arguments(self):
-        return self.get_signature().get_number_of_signature_arguments()
+        return self._signature.get_number_of_signature_arguments()
 
     def invoke_1(node, rcvr):  # pylint: disable=no-self-argument
         jitdriver_1.jit_merge_point(node=node, rcvr=rcvr)

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -97,6 +97,7 @@ class BcAbstractMethod(AbstractMethod):
     def get_number_of_arguments(self):
         return self._number_of_arguments
 
+    @jit.elidable_promote("all")
     def get_number_of_signature_arguments(self):
         return self._number_of_arguments
 

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,57 +1,56 @@
-import unittest
 from som.vm.globals import trueObject
 from som.vmobjects.array import Array
-from som.vmobjects.array import _EmptyStrategy  # pylint: disable=protected-access
-from som.vmobjects.array import _ObjectStrategy  # pylint: disable=protected-access
-from som.vmobjects.array import _LongStrategy  # pylint: disable=protected-access
-from som.vmobjects.array import _PartiallyEmptyStrategy  # pylint: disable=W
-from som.vmobjects.array import _BoolStrategy  # pylint: disable=protected-access
+from som.vmobjects.array import _empty_strategy  # pylint: disable=protected-access
+from som.vmobjects.array import _obj_strategy  # pylint: disable=protected-access
+from som.vmobjects.array import _long_strategy  # pylint: disable=protected-access
+from som.vmobjects.array import _partially_empty_strategy  # pylint: disable=W
+from som.vmobjects.array import _bool_strategy  # pylint: disable=protected-access
 
 from som.vmobjects.integer import Integer
 
 
-class ArrayTest(unittest.TestCase):
-    def assert_strategy(self, arr, strategy):
-        self.assertIsInstance(arr.strategy, strategy)  # pylint: disable=W
+def test_empty_array():
+    arr = Array.from_size(0)
+    assert arr.strategy is _empty_strategy
 
-    def test_empty_array(self):
-        arr = Array.from_size(0)
-        self.assert_strategy(arr, _EmptyStrategy)
 
-    def test_empty_to_obj(self):
-        arr = Array.from_size(1)
-        self.assert_strategy(arr, _EmptyStrategy)
+def test_empty_to_obj():
+    arr = Array.from_size(1)
+    assert arr.strategy is _empty_strategy
 
-        arr.set_indexable_field(0, arr)
-        self.assert_strategy(arr, _ObjectStrategy)
-        self.assertIs(arr, arr.get_indexable_field(0))
+    arr.set_indexable_field(0, arr)
+    assert arr.strategy is _obj_strategy
+    assert arr is arr.get_indexable_field(0)
 
-    def test_empty_to_int(self):
-        arr = Array.from_size(1)
-        self.assert_strategy(arr, _EmptyStrategy)
 
-        int_obj = Integer(42)
+def test_empty_to_int():
+    arr = Array.from_size(1)
+    assert arr.strategy is _empty_strategy
 
-        arr.set_indexable_field(0, int_obj)
-        self.assert_strategy(arr, _LongStrategy)
-        self.assertEqual(42, arr.get_indexable_field(0).get_embedded_integer())
+    int_obj = Integer(42)
 
-    def test_empty_to_bool(self):
-        arr = Array.from_size(1)
-        self.assert_strategy(arr, _EmptyStrategy)
+    arr.set_indexable_field(0, int_obj)
+    assert arr.strategy is _long_strategy
+    assert arr.get_indexable_field(0).get_embedded_integer() == 42
 
-        arr.set_indexable_field(0, trueObject)
-        self.assert_strategy(arr, _BoolStrategy)
-        self.assertEqual(trueObject, arr.get_indexable_field(0))
 
-    def test_copy_and_extend_partially_empty(self):
-        arr = Array.from_size(3)
+def test_empty_to_bool():
+    arr = Array.from_size(1)
+    assert arr.strategy is _empty_strategy
 
-        int_obj = Integer(42)
-        arr.set_indexable_field(0, int_obj)
-        self.assert_strategy(arr, _PartiallyEmptyStrategy)
-        new_arr = arr.copy_and_extend_with(int_obj)
+    arr.set_indexable_field(0, trueObject)
+    assert arr.strategy is _bool_strategy
+    assert trueObject is arr.get_indexable_field(0)
 
-        self.assertIsNot(arr, new_arr)
-        self.assertEqual(4, new_arr.get_number_of_indexable_fields())
-        self.assert_strategy(new_arr, _PartiallyEmptyStrategy)
+
+def test_copy_and_extend_partially_empty():
+    arr = Array.from_size(3)
+
+    int_obj = Integer(42)
+    arr.set_indexable_field(0, int_obj)
+    assert arr.strategy is _partially_empty_strategy
+    new_arr = arr.copy_and_extend_with(int_obj)
+
+    assert arr is not new_arr
+    assert new_arr.get_number_of_indexable_fields() == 4
+    assert new_arr.strategy is _partially_empty_strategy

--- a/tests/test_bc_frame.py
+++ b/tests/test_bc_frame.py
@@ -1,5 +1,3 @@
-import unittest
-
 from som.interpreter.ast.frame import (
     FRAME_AND_INNER_RCVR_IDX,
     read_frame,
@@ -15,166 +13,133 @@ from som.vmobjects.integer import Integer
 _MIN_FRAME_SIZE = 1 + 1  # Inner, Receiver
 
 
-class FrameTest(unittest.TestCase):
-    def test_call_argument_handling_all_frame(self):
-        num_args = 4
-        prev_stack = [Integer(i) for i in range(num_args)]
+def test_call_argument_handling_all_frame():
+    num_args = 4
+    prev_stack = [Integer(i) for i in range(num_args)]
 
-        callee_frame = create_frame(
-            [False] * (num_args - 1),
-            _MIN_FRAME_SIZE + num_args,
-            0,
-            prev_stack,
-            num_args - 1,
-            num_args,
-        )
+    callee_frame = create_frame(
+        [False] * (num_args - 1),
+        _MIN_FRAME_SIZE + num_args,
+        0,
+        prev_stack,
+        num_args - 1,
+        num_args,
+    )
 
-        for i in range(num_args):
-            self.assertEqual(
-                i,
-                read_frame(
-                    callee_frame, FRAME_AND_INNER_RCVR_IDX + i
-                ).get_embedded_integer(),
-            )
-
-    def test_call_argument_handling_mix_frame_and_inner(self):
-        num_args = 6
-        prev_stack = [Integer(i) for i in range(num_args)]
-
-        arg_access_inner = [True, False, True, False, True]
-        arg_access_inner.reverse()
-        callee_frame = create_frame(
-            arg_access_inner,
-            _MIN_FRAME_SIZE + num_args,
-            2 + 3,
-            prev_stack,
-            num_args - 1,
-            num_args,
+    for i in range(num_args):
+        assert (
+            i
+            == read_frame(
+                callee_frame, FRAME_AND_INNER_RCVR_IDX + i
+            ).get_embedded_integer()
         )
 
-        self.assertEqual(
-            0, read_frame(callee_frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer()
-        )
-        self.assertEqual(
-            1,
-            read_inner(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 1
-            ).get_embedded_integer(),
-        )
-        self.assertEqual(
-            2,
-            read_frame(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 1
-            ).get_embedded_integer(),
-        )
-        self.assertEqual(
-            3,
-            read_inner(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 2
-            ).get_embedded_integer(),
-        )
-        self.assertEqual(
-            4,
-            read_frame(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 2
-            ).get_embedded_integer(),
-        )
-        self.assertEqual(
-            5,
-            read_inner(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 3
-            ).get_embedded_integer(),
-        )
 
-    def test_call_argument_handling_first_frame_then_inner(self):
-        num_args = 6
+def test_call_argument_handling_mix_frame_and_inner():
+    num_args = 6
+    prev_stack = [Integer(i) for i in range(num_args)]
 
-        prev_stack = [Integer(i) for i in range(num_args)]
+    arg_access_inner = [True, False, True, False, True]
+    arg_access_inner.reverse()
+    callee_frame = create_frame(
+        arg_access_inner,
+        _MIN_FRAME_SIZE + num_args,
+        2 + 3,
+        prev_stack,
+        num_args - 1,
+        num_args,
+    )
 
-        arg_access_inner = [False, False, False, True, True]
-        arg_access_inner.reverse()
-        callee_frame = create_frame(
-            arg_access_inner,
-            _MIN_FRAME_SIZE + num_args,
-            2 + 3,
-            prev_stack,
-            num_args - 1,
-            num_args,
-        )
+    assert (
+        read_frame(callee_frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer() == 0
+    )
+    assert (
+        read_inner(callee_frame, FRAME_AND_INNER_RCVR_IDX + 1).get_embedded_integer()
+        == 1
+    )
+    assert (
+        read_frame(callee_frame, FRAME_AND_INNER_RCVR_IDX + 1).get_embedded_integer()
+        == 2
+    )
+    assert (
+        read_inner(callee_frame, FRAME_AND_INNER_RCVR_IDX + 2).get_embedded_integer()
+        == 3
+    )
+    assert (
+        read_frame(callee_frame, FRAME_AND_INNER_RCVR_IDX + 2).get_embedded_integer()
+        == 4
+    )
 
-        self.assertEqual(
-            0, read_frame(callee_frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer()
-        )
-        self.assertEqual(
-            1,
-            read_frame(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 1
-            ).get_embedded_integer(),
-        )
-        self.assertEqual(
-            2,
-            read_frame(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 2
-            ).get_embedded_integer(),
-        )
-        self.assertEqual(
-            3,
-            read_frame(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 3
-            ).get_embedded_integer(),
-        )
-        self.assertEqual(
-            4,
-            read_inner(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 1
-            ).get_embedded_integer(),
-        )
-        self.assertEqual(
-            5,
-            read_inner(
-                callee_frame, FRAME_AND_INNER_RCVR_IDX + 2
-            ).get_embedded_integer(),
-        )
+    assert (
+        read_inner(callee_frame, FRAME_AND_INNER_RCVR_IDX + 3).get_embedded_integer()
+        == 5
+    )
 
-    def test_create_frame_1(self):
-        rcvr = Integer(1)
-        frame = create_frame_1(rcvr, _MIN_FRAME_SIZE, _MIN_FRAME_SIZE)
 
-        self.assertEqual(
-            1, read_inner(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer()
-        )
-        self.assertEqual(
-            1, read_frame(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer()
-        )
+def test_call_argument_handling_first_frame_then_inner():
+    num_args = 6
 
-    def test_create_frame_2_inner(self):
-        rcvr = Integer(1)
-        arg = Integer(2)
-        frame = create_frame_2(rcvr, arg, True, _MIN_FRAME_SIZE, _MIN_FRAME_SIZE + 1)
+    prev_stack = [Integer(i) for i in range(num_args)]
 
-        self.assertEqual(
-            1, read_inner(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer()
-        )
-        self.assertEqual(
-            1, read_frame(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer()
-        )
+    arg_access_inner = [False, False, False, True, True]
+    arg_access_inner.reverse()
+    callee_frame = create_frame(
+        arg_access_inner,
+        _MIN_FRAME_SIZE + num_args,
+        2 + 3,
+        prev_stack,
+        num_args - 1,
+        num_args,
+    )
 
-        self.assertEqual(
-            2, read_inner(frame, FRAME_AND_INNER_RCVR_IDX + 1).get_embedded_integer()
-        )
+    assert (
+        read_frame(callee_frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer() == 0
+    )
+    assert (
+        read_frame(callee_frame, FRAME_AND_INNER_RCVR_IDX + 1).get_embedded_integer()
+        == 1
+    )
+    assert (
+        read_frame(callee_frame, FRAME_AND_INNER_RCVR_IDX + 2).get_embedded_integer()
+        == 2
+    )
+    assert (
+        read_frame(callee_frame, FRAME_AND_INNER_RCVR_IDX + 3).get_embedded_integer()
+        == 3
+    )
+    assert (
+        read_inner(callee_frame, FRAME_AND_INNER_RCVR_IDX + 1).get_embedded_integer()
+        == 4
+    )
+    assert (
+        read_inner(callee_frame, FRAME_AND_INNER_RCVR_IDX + 2).get_embedded_integer()
+        == 5
+    )
 
-    def test_create_frame_2_frame(self):
-        rcvr = Integer(1)
-        arg = Integer(2)
-        frame = create_frame_2(rcvr, arg, False, _MIN_FRAME_SIZE + 1, _MIN_FRAME_SIZE)
 
-        self.assertEqual(
-            1, read_inner(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer()
-        )
-        self.assertEqual(
-            1, read_frame(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer()
-        )
+def test_create_frame_1():
+    rcvr = Integer(1)
+    frame = create_frame_1(rcvr, _MIN_FRAME_SIZE, _MIN_FRAME_SIZE)
 
-        self.assertEqual(
-            2, read_frame(frame, FRAME_AND_INNER_RCVR_IDX + 1).get_embedded_integer()
-        )
+    assert read_inner(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer() == 1
+    assert read_frame(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer() == 1
+
+
+def test_create_frame_2_inner():
+    rcvr = Integer(1)
+    arg = Integer(2)
+    frame = create_frame_2(rcvr, arg, True, _MIN_FRAME_SIZE, _MIN_FRAME_SIZE + 1)
+
+    assert read_inner(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer() == 1
+    assert read_frame(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer() == 1
+    assert read_inner(frame, FRAME_AND_INNER_RCVR_IDX + 1).get_embedded_integer() == 2
+
+
+def test_create_frame_2_frame():
+    rcvr = Integer(1)
+    arg = Integer(2)
+    frame = create_frame_2(rcvr, arg, False, _MIN_FRAME_SIZE + 1, _MIN_FRAME_SIZE)
+
+    assert read_inner(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer() == 1
+    assert read_frame(frame, FRAME_AND_INNER_RCVR_IDX).get_embedded_integer() == 1
+    assert read_frame(frame, FRAME_AND_INNER_RCVR_IDX + 1).get_embedded_integer() == 2

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+# pylint: disable=redefined-outer-name
 import pytest
 from rlib.string_stream import StringStream
 
@@ -11,165 +11,198 @@ from som.interpreter.bc.bytecodes import Bytecodes
 from som.vm.current import current_universe
 
 
-class BytecodeGenerationTest(TestCase):
-    def setUp(self):
-        self.cgenc = None
-        self.mgenc = None
-
-    def add_field(self, name):
-        self.cgenc.add_instance_field(current_universe.symbol_for(name))
-
-    def dump(self):
-        dump_method(self.mgenc, "")
-
-
-@pytest.mark.skipif(
+pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
     is_ast_interpreter(), reason="Tests are specific to bytecode interpreter"
 )
-class BytecodeMethodGenerationTest(BytecodeGenerationTest):
-    def setUp(self):
-        self.cgenc = ClassGenerationContext(current_universe)
-        self.mgenc = MethodGenerationContext(current_universe, self.cgenc, None)
-        self.mgenc.add_argument("self")
-
-    def parse_to_bytecodes(self, source):
-        parser = Parser(StringStream(source), "test", current_universe)
-
-        parser.method(self.mgenc)
-        return self.mgenc.get_bytecodes()
-
-    def test_empty_method_returns_self(self):
-        bytecodes = self.parse_to_bytecodes("test = ( )")
-
-        self.assertEqual(1, len(bytecodes))
-        self.assertEqual(Bytecodes.return_self, bytecodes[0])
-
-    def test_explicit_return_self(self):
-        bytecodes = self.parse_to_bytecodes("test = ( ^ self )")
-
-        self.assertEqual(1, len(bytecodes))
-        self.assertEqual(Bytecodes.return_self, bytecodes[0])
-
-    def test_dup_pop_argument_pop(self):
-        bytecodes = self.parse_to_bytecodes("test: arg = ( arg := 1. ^ self )")
-
-        self.assertEqual(5, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.pop_argument, bytecodes[1])
-        self.assertEqual(Bytecodes.return_self, bytecodes[4])
-
-    def test_dup_pop_argument_pop_implicit_return_self(self):
-        bytecodes = self.parse_to_bytecodes("test: arg = ( arg := 1 )")
-
-        self.assertEqual(5, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.pop_argument, bytecodes[1])
-        self.assertEqual(Bytecodes.return_self, bytecodes[4])
-
-    def test_dup_pop_local_pop(self):
-        bytecodes = self.parse_to_bytecodes("test = ( | local | local := 1. ^ self )")
-
-        self.assertEqual(5, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.pop_local, bytecodes[1])
-        self.assertEqual(Bytecodes.return_self, bytecodes[4])
-
-    def test_dup_pop_field_0_pop(self):
-        self.add_field("field")
-        bytecodes = self.parse_to_bytecodes("test = ( field := 1. ^ self )")
-
-        self.assertEqual(5, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_field_0, bytecodes[2])
-        self.assertEqual(Bytecodes.pop, bytecodes[3])
-
-    def test_dup_pop_field_pop(self):
-        self.add_field("a")
-        self.add_field("b")
-        self.add_field("c")
-        self.add_field("d")
-        self.add_field("field")
-        bytecodes = self.parse_to_bytecodes("test = ( field := 1. ^ self )")
-
-        self.assertEqual(5, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.pop_field, bytecodes[1])
-        self.assertEqual(Bytecodes.return_self, bytecodes[4])
 
 
-@pytest.mark.skipif(
-    is_ast_interpreter(), reason="Tests are specific to bytecode interpreter"
-)
-class BytecodeBlockGenerationTest(BytecodeGenerationTest):
-    def setUp(self):
-        self.cgenc = ClassGenerationContext(current_universe)
-        self.method_mgenc = MethodGenerationContext(current_universe, self.cgenc, None)
-        self.method_mgenc.add_argument("self")
+def add_field(cgenc, name):
+    cgenc.add_instance_field(current_universe.symbol_for(name))
 
-        self.mgenc = MethodGenerationContext(
-            current_universe, self.cgenc, self.method_mgenc
-        )
-        self.mgenc.add_argument("$blockSelf")
 
-    def parse_to_bytecodes(self, source):
-        parser = Parser(StringStream(source), "test", current_universe)
+def dump(mgenc):
+    dump_method(mgenc, "")
 
-        parser.nested_block(self.mgenc)
-        return self.mgenc.get_bytecodes()
 
-    def test_block_dup_pop_argument_pop(self):
-        bytecodes = self.parse_to_bytecodes("[:arg | arg := 1. arg ]")
+@pytest.fixture
+def cgenc():
+    return ClassGenerationContext(current_universe)
 
-        self.assertEqual(8, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.pop_argument, bytecodes[1])
-        self.assertEqual(Bytecodes.push_argument, bytecodes[4])
-        self.assertEqual(Bytecodes.return_local, bytecodes[7])
 
-    def test_block_dup_pop_argument_pop_implicit_return_self(self):
-        bytecodes = self.parse_to_bytecodes("[:arg | arg := 1 ]")
+@pytest.fixture
+def mgenc(cgenc):
+    mgenc = MethodGenerationContext(current_universe, cgenc, None)
+    mgenc.add_argument("self")
+    return mgenc
 
-        self.assertEqual(6, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_argument, bytecodes[2])
-        self.assertEqual(Bytecodes.return_local, bytecodes[5])
 
-    def test_block_dup_pop_argument_pop_implicit_return_self_dot(self):
-        bytecodes = self.parse_to_bytecodes("[:arg | arg := 1. ]")
+@pytest.fixture
+def bgenc(cgenc, mgenc):
+    bgenc = MethodGenerationContext(current_universe, cgenc, mgenc)
+    bgenc.add_argument("$blockSelf")
+    return bgenc
 
-        self.assertEqual(6, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_argument, bytecodes[2])
-        self.assertEqual(Bytecodes.return_local, bytecodes[5])
 
-    def test_block_dup_pop_local_return_local(self):
-        bytecodes = self.parse_to_bytecodes("[| local | local := 1 ]")
+def method_to_bytecodes(mgenc, source):
+    parser = Parser(StringStream(source), "test", current_universe)
+    parser.method(mgenc)
+    return mgenc.get_bytecodes()
 
-        self.assertEqual(6, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_local, bytecodes[2])
-        self.assertEqual(Bytecodes.return_local, bytecodes[5])
 
-    def test_block_dup_pop_field_return_local(self):
-        self.add_field("field")
-        bytecodes = self.parse_to_bytecodes("[ field := 1 ]")
+def block_to_bytecodes(bgenc, source):
+    parser = Parser(StringStream(source), "test", current_universe)
 
-        self.assertEqual(6, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_field, bytecodes[2])
-        self.assertEqual(Bytecodes.return_local, bytecodes[5])
+    parser.nested_block(bgenc)
+    return bgenc.get_bytecodes()
 
-    def test_block_dup_pop_field_return_local_dot(self):
-        self.add_field("field")
-        bytecodes = self.parse_to_bytecodes("[ field := 1. ]")
 
-        self.assertEqual(6, len(bytecodes))
-        self.assertEqual(Bytecodes.push_1, bytecodes[0])
-        self.assertEqual(Bytecodes.dup, bytecodes[1])
-        self.assertEqual(Bytecodes.pop_field, bytecodes[2])
-        self.assertEqual(Bytecodes.return_local, bytecodes[5])
+def test_empty_method_returns_self(mgenc):
+    bytecodes = method_to_bytecodes(mgenc, "test = ( )")
+
+    assert len(bytecodes) == 1
+    assert bytecodes[0] == Bytecodes.return_self
+
+
+def test_explicit_return_self(mgenc):
+    bytecodes = method_to_bytecodes(mgenc, "test = ( ^ self )")
+
+    assert len(bytecodes) == 1
+    assert bytecodes[0] == Bytecodes.return_self
+
+
+def test_dup_pop_argument_pop(mgenc):
+    bytecodes = method_to_bytecodes(mgenc, "test: arg = ( arg := 1. ^ self )")
+
+    assert len(bytecodes) == 5
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.pop_argument == bytecodes[1]
+    assert Bytecodes.return_self == bytecodes[4]
+
+
+def test_dup_pop_argument_pop_implicit_return_self(mgenc):
+    bytecodes = method_to_bytecodes(mgenc, "test: arg = ( arg := 1 )")
+
+    assert len(bytecodes) == 5
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.pop_argument == bytecodes[1]
+    assert Bytecodes.return_self == bytecodes[4]
+
+
+def test_dup_pop_local_pop(mgenc):
+    bytecodes = method_to_bytecodes(mgenc, "test = ( | local | local := 1. ^ self )")
+
+    assert len(bytecodes) == 5
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.pop_local == bytecodes[1]
+    assert Bytecodes.return_self == bytecodes[4]
+
+
+def test_dup_pop_field_0_pop(cgenc, mgenc):
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(mgenc, "test = ( field := 1. ^ self )")
+
+    assert len(bytecodes) == 3
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.pop_field_0 == bytecodes[1]
+    assert Bytecodes.return_self == bytecodes[2]
+
+
+def test_dup_pop_field_pop(cgenc, mgenc):
+    add_field(cgenc, "a")
+    add_field(cgenc, "b")
+    add_field(cgenc, "c")
+    add_field(cgenc, "d")
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(mgenc, "test = ( field := 1. ^ self )")
+
+    assert len(bytecodes) == 5
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.pop_field == bytecodes[1]
+    assert Bytecodes.return_self == bytecodes[4]
+
+
+def test_dup_pop_field_return_self(cgenc, mgenc):
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(mgenc, "test: val = ( field := val )")
+
+    assert len(bytecodes) == 5
+    assert Bytecodes.push_argument == bytecodes[0]
+    assert Bytecodes.pop_field_0 == bytecodes[3]
+    assert Bytecodes.return_self == bytecodes[4]
+
+
+def test_dup_pop_field_n_return_self(cgenc, mgenc):
+    add_field(cgenc, "a")
+    add_field(cgenc, "b")
+    add_field(cgenc, "c")
+    add_field(cgenc, "d")
+    add_field(cgenc, "e")
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(mgenc, "test: value = ( field := value )")
+
+    assert len(bytecodes) == 7
+    assert Bytecodes.push_argument == bytecodes[0]
+    assert Bytecodes.pop_field == bytecodes[3]
+    assert Bytecodes.return_self == bytecodes[6]
+
+
+def test_block_dup_pop_argument_pop(bgenc):
+    bytecodes = block_to_bytecodes(bgenc, "[:arg | arg := 1. arg ]")
+
+    assert len(bytecodes) == 8
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.pop_argument == bytecodes[1]
+    assert Bytecodes.push_argument == bytecodes[4]
+    assert Bytecodes.return_local == bytecodes[7]
+
+
+def test_block_dup_pop_argument_pop_implicit_return_self(bgenc):
+    bytecodes = block_to_bytecodes(bgenc, "[:arg | arg := 1 ]")
+
+    assert len(bytecodes) == 6
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.dup == bytecodes[1]
+    assert Bytecodes.pop_argument == bytecodes[2]
+    assert Bytecodes.return_local == bytecodes[5]
+
+
+def test_block_dup_pop_argument_pop_implicit_return_self_dot(bgenc):
+    bytecodes = block_to_bytecodes(bgenc, "[:arg | arg := 1. ]")
+
+    assert len(bytecodes) == 6
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.dup == bytecodes[1]
+    assert Bytecodes.pop_argument == bytecodes[2]
+    assert Bytecodes.return_local == bytecodes[5]
+
+
+def test_block_dup_pop_local_return_local(bgenc):
+    bytecodes = block_to_bytecodes(bgenc, "[| local | local := 1 ]")
+
+    assert len(bytecodes) == 6
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.dup == bytecodes[1]
+    assert Bytecodes.pop_local == bytecodes[2]
+    assert Bytecodes.return_local == bytecodes[5]
+
+
+def test_block_dup_pop_field_return_local(cgenc, bgenc):
+    add_field(cgenc, "field")
+    bytecodes = block_to_bytecodes(bgenc, "[ field := 1 ]")
+
+    assert len(bytecodes) == 6
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.dup == bytecodes[1]
+    assert Bytecodes.pop_field == bytecodes[2]
+    assert Bytecodes.return_local == bytecodes[5]
+
+
+def test_block_dup_pop_field_return_local_dot(cgenc, bgenc):
+    add_field(cgenc, "field")
+    bytecodes = block_to_bytecodes(bgenc, "[ field := 1. ]")
+
+    assert len(bytecodes) == 6
+    assert Bytecodes.push_1 == bytecodes[0]
+    assert Bytecodes.dup == bytecodes[1]
+    assert Bytecodes.pop_field == bytecodes[2]
+    assert Bytecodes.return_local == bytecodes[5]

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -146,6 +146,30 @@ def test_dup_pop_field_n_return_self(cgenc, mgenc):
     assert Bytecodes.return_self == bytecodes[6]
 
 
+def test_send_dup_pop_field_return_local(cgenc, mgenc):
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(mgenc, "test = ( ^ field := self method )")
+
+    assert len(bytecodes) == 8
+    assert Bytecodes.push_argument == bytecodes[0]
+    assert Bytecodes.send_1 == bytecodes[3]
+    assert Bytecodes.dup == bytecodes[5]
+    assert Bytecodes.pop_field_0 == bytecodes[6]
+    assert Bytecodes.return_local == bytecodes[7]
+
+
+def test_send_dup_pop_field_return_local_period(cgenc, mgenc):
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(mgenc, "test = ( ^ field := self method. )")
+
+    assert len(bytecodes) == 8
+    assert Bytecodes.push_argument == bytecodes[0]
+    assert Bytecodes.send_1 == bytecodes[3]
+    assert Bytecodes.dup == bytecodes[5]
+    assert Bytecodes.pop_field_0 == bytecodes[6]
+    assert Bytecodes.return_local == bytecodes[7]
+
+
 def test_block_dup_pop_argument_pop(bgenc):
     bytecodes = block_to_bytecodes(bgenc, "[:arg | arg := 1. arg ]")
 


### PR DESCRIPTION
This PR makes the DUP-POP X-POP optimization more robust and fix the missing support for pop_field_x bytecodes.

It also changes the style of tests to use PyTest style consistently with other tests.
This will help down the line to use parameterized tests, and avoid copying undesirable style when adding new tests.