### PR TITLE
Optimize Trivial Methods to avoid needing a frame

### DIFF
--- a/src/som/compiler/ast/method_generation_context.py
+++ b/src/som/compiler/ast/method_generation_context.py
@@ -40,6 +40,10 @@ class MethodGenerationContext(MethodGenerationContextBase):
                 method_body, method_body.source_section
             )
 
+        trivial_method = method_body.create_trivial_method(self._signature)
+        if trivial_method is not None:
+            return trivial_method
+
         arg_inner_access, size_frame, size_inner = self.prepare_frame()
 
         # method_body = self._add_argument_initialization(method_body)

--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -6,7 +6,6 @@ from som.compiler.parser import ParserBase
 from som.compiler.symbol import Symbol
 
 from som.interpreter.ast.nodes.block_node import BlockNode, BlockNodeWithContext
-from som.interpreter.ast.nodes.global_read_node import create_global_node
 from som.interpreter.ast.nodes.literal_node import LiteralNode
 from som.interpreter.ast.nodes.message.super_node import (
     UnarySuper,
@@ -72,13 +71,9 @@ class Parser(ParserBase):
 
     def _create_sequence_node(self, coordinate, expressions):
         if not expressions:
-            nil_exp = create_global_node(
-                self.universe.sym_nil,
-                self.universe,
-                None,
-                self._get_source_section(coordinate),
-            )
-            return nil_exp
+            from som.vm.globals import nilObject
+
+            return LiteralNode(nilObject)
         if len(expressions) == 1:
             return expressions[0]
 

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -100,9 +100,9 @@ class MethodGenerationContext(MethodGenerationContextBase):
         if self._primitive:
             return empty_primitive(self._signature.get_embedded_string(), self.universe)
 
-        method = self.assemble_trivial_method()
-        if method is not None:
-            return method
+        trivial_method = self.assemble_trivial_method()
+        if trivial_method is not None:
+            return trivial_method
 
         arg_inner_access, size_frame, size_inner = self.prepare_frame()
 

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -126,8 +126,8 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
             return FieldRead(self._signature, idx, ctx)
 
-        if self.is_field_setter():
-            pass
+        # if self.is_field_setter():
+        #     pass
 
         return None
 

--- a/src/som/interpreter/ast/nodes/block_node.py
+++ b/src/som/interpreter/ast/nodes/block_node.py
@@ -14,6 +14,9 @@ class BlockNode(LiteralNode):
     def execute(self, _frame):
         return AstBlock(self._value, None)
 
+    def create_trivial_method(self, signature):
+        return None
+
 
 class BlockNodeWithContext(BlockNode):
     def __init__(self, value, universe, source_section=None):

--- a/src/som/interpreter/ast/nodes/expression_node.py
+++ b/src/som/interpreter/ast/nodes/expression_node.py
@@ -4,3 +4,9 @@ from rtruffle.node import Node
 class ExpressionNode(Node):
     def __init__(self, source_section):
         Node.__init__(self, source_section)
+
+    def create_trivial_method(self, _signature):  # pylint: disable=no-self-use
+        return None
+
+    def is_trivial_in_sequence(self):  # pylint: disable=no-self-use
+        return False

--- a/src/som/interpreter/ast/nodes/global_read_node.py
+++ b/src/som/interpreter/ast/nodes/global_read_node.py
@@ -1,4 +1,5 @@
 from som.interpreter.ast.nodes.contextual_node import ContextualNode
+from som.interpreter.ast.nodes.literal_node import LiteralNode
 from som.interpreter.send import lookup_and_send_2
 from som.vm.globals import nilObject, trueObject, falseObject
 
@@ -9,11 +10,11 @@ from som.vmobjects.method_trivial import GlobalRead
 def create_global_node(global_name, universe, mgenc, source_section):
     glob = global_name.get_embedded_string()
     if glob == "true":
-        return _ConstantGlobalReadNode(trueObject, source_section)
+        return LiteralNode(trueObject, source_section)
     if glob == "false":
-        return _ConstantGlobalReadNode(falseObject, source_section)
+        return LiteralNode(falseObject, source_section)
     if glob == "nil":
-        return _ConstantGlobalReadNode(nilObject, source_section)
+        return LiteralNode(nilObject, source_section)
 
     assoc = universe.get_globals_association_or_none(global_name)
     if assoc is not None:
@@ -66,16 +67,5 @@ class _CachedGlobalReadNode(ExpressionNode):
     def execute(self, _frame):
         return self._assoc.value
 
-
-class _ConstantGlobalReadNode(ExpressionNode):
-
-    _immutable_fields_ = ["_value"]
-
-    def __init__(self, value, source_section):
-        ExpressionNode.__init__(self, source_section)
-        self._value = value
-
-    def execute(self, _frame):
-        return self._value
     def create_trivial_method(self, signature):
         return GlobalRead(signature, None, 0, None, self._assoc)

--- a/src/som/interpreter/ast/nodes/global_read_node.py
+++ b/src/som/interpreter/ast/nodes/global_read_node.py
@@ -3,6 +3,7 @@ from som.interpreter.send import lookup_and_send_2
 from som.vm.globals import nilObject, trueObject, falseObject
 
 from som.interpreter.ast.nodes.expression_node import ExpressionNode
+from som.vmobjects.method_trivial import GlobalRead
 
 
 def create_global_node(global_name, universe, mgenc, source_section):
@@ -48,6 +49,11 @@ class _UninitializedGlobalReadNode(ContextualNode):
         cached = _CachedGlobalReadNode(assoc, self.source_section)
         return self.replace(cached)
 
+    def create_trivial_method(self, signature):
+        return GlobalRead(
+            signature, self._global_name, self._context_level, self.universe
+        )
+
 
 class _CachedGlobalReadNode(ExpressionNode):
 
@@ -71,3 +77,5 @@ class _ConstantGlobalReadNode(ExpressionNode):
 
     def execute(self, _frame):
         return self._value
+    def create_trivial_method(self, signature):
+        return GlobalRead(signature, None, 0, None, self._assoc)

--- a/src/som/interpreter/ast/nodes/literal_node.py
+++ b/src/som/interpreter/ast/nodes/literal_node.py
@@ -1,4 +1,5 @@
 from som.interpreter.ast.nodes.expression_node import ExpressionNode
+from som.vmobjects.method_trivial import LiteralReturn
 
 
 class LiteralNode(ExpressionNode):
@@ -11,3 +12,6 @@ class LiteralNode(ExpressionNode):
 
     def execute(self, _frame):
         return self._value
+
+    def create_trivial_method(self, signature):
+        return LiteralReturn(signature, self._value)

--- a/src/som/interpreter/ast/nodes/sequence_node.py
+++ b/src/som/interpreter/ast/nodes/sequence_node.py
@@ -1,6 +1,7 @@
 from rlib.jit import unroll_safe
 
 from som.interpreter.ast.nodes.expression_node import ExpressionNode
+from som.interpreter.ast.nodes.variable_node import LocalFrameVarReadNode
 
 
 class SequenceNode(ExpressionNode):
@@ -20,3 +21,15 @@ class SequenceNode(ExpressionNode):
     def _execute_all_but_last(self, frame):
         for i in range(0, len(self._exprs) - 1):
             self._exprs[i].execute(frame)
+
+    def create_trivial_method(self, signature):
+        if len(self._exprs) != 2:
+            return None
+
+        return_exp = self._exprs[1]
+        if isinstance(return_exp, LocalFrameVarReadNode) and return_exp.is_self():
+            expr = self._exprs[0]
+            if expr.is_trivial_in_sequence():
+                return expr.create_trivial_method(signature)
+
+        return None

--- a/src/som/interpreter/ast/nodes/variable_node.py
+++ b/src/som/interpreter/ast/nodes/variable_node.py
@@ -1,4 +1,10 @@
-from som.interpreter.ast.frame import read_frame, read_inner, write_inner, write_frame
+from som.interpreter.ast.frame import (
+    read_frame,
+    read_inner,
+    write_inner,
+    write_frame,
+    FRAME_AND_INNER_RCVR_IDX,
+)
 from som.vmobjects.block_ast import AstBlock
 
 from som.interpreter.ast.nodes.contextual_node import ContextualNode
@@ -7,11 +13,11 @@ from som.interpreter.ast.nodes.expression_node import ExpressionNode
 
 class UninitializedReadNode(ExpressionNode):
 
-    _immutable_fields_ = ["_var", "_context_level"]
+    _immutable_fields_ = ["var", "_context_level"]
 
     def __init__(self, var, context_level, source_section):
         ExpressionNode.__init__(self, source_section)
-        self._var = var
+        self.var = var
         self._context_level = context_level
 
     def execute(self, frame):
@@ -19,9 +25,7 @@ class UninitializedReadNode(ExpressionNode):
 
     def _specialize(self):
         return self.replace(
-            self._var.get_initialized_read_node(
-                self._context_level, self.source_section
-            )
+            self.var.get_initialized_read_node(self._context_level, self.source_section)
         )
 
 
@@ -116,6 +120,9 @@ class LocalInnerVarWriteNode(_LocalVariableWriteNode):
 class LocalFrameVarReadNode(_LocalVariableNode):
     def execute(self, frame):
         return read_frame(frame, self._frame_idx)
+
+    def is_self(self):
+        return self._frame_idx == FRAME_AND_INNER_RCVR_IDX
 
 
 class LocalFrameVarWriteNode(_LocalVariableWriteNode):

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -88,6 +88,16 @@ POP_X_BYTECODES = [
     Bytecodes.pop_field_1,
 ]
 
+PUSH_CONST_BYTECODES = [
+    Bytecodes.push_constant,
+    Bytecodes.push_constant_0,
+    Bytecodes.push_constant_1,
+    Bytecodes.push_constant_2,
+    Bytecodes.push_0,
+    Bytecodes.push_1,
+    Bytecodes.push_nil,
+]
+
 _BYTECODE_LENGTH = [
     1,  # halt
     1,  # dup

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -98,6 +98,18 @@ PUSH_CONST_BYTECODES = [
     Bytecodes.push_nil,
 ]
 
+PUSH_FIELD_BYTECODES = [
+    Bytecodes.push_field,
+    Bytecodes.push_field_0,
+    Bytecodes.push_field_1,
+]
+
+POP_FIELD_BYTECODES = [
+    Bytecodes.pop_field,
+    Bytecodes.pop_field_0,
+    Bytecodes.pop_field_1,
+]
+
 _BYTECODE_LENGTH = [
     1,  # halt
     1,  # dup

--- a/src/som/vmobjects/method_trivial.py
+++ b/src/som/vmobjects/method_trivial.py
@@ -40,6 +40,11 @@ class LiteralReturn(AbstractTrivialMethod):
         AbstractTrivialMethod.__init__(self, signature)
         self._value = value
 
+    def set_holder(self, value):
+        self._holder = value
+        if isinstance(self._value, AbstractMethod):
+            self._value.set_holder(value)
+
     def invoke_1(self, _rcvr):
         return self._value
 
@@ -61,9 +66,9 @@ class LiteralReturn(AbstractTrivialMethod):
 class GlobalRead(AbstractTrivialMethod):
     _immutable_fields_ = ["_assoc?", "_global_name", "_context_level", "universe"]
 
-    def __init__(self, signature, global_name, context_level, universe):
+    def __init__(self, signature, global_name, context_level, universe, assoc=None):
         AbstractTrivialMethod.__init__(self, signature)
-        self._assoc = None
+        self._assoc = assoc
         self._global_name = global_name
         self._context_level = context_level
 

--- a/src/som/vmobjects/method_trivial.py
+++ b/src/som/vmobjects/method_trivial.py
@@ -132,3 +132,38 @@ class FieldRead(AbstractTrivialMethod):
             num_args,
             value,
         )
+
+
+class FieldWrite(AbstractTrivialMethod):
+    _immutable_fields_ = ["_field_idx", "_arg_idx"]
+
+    def __init__(self, signature, field_idx, arg_idx):
+        AbstractTrivialMethod.__init__(self, signature)
+        self._field_idx = field_idx
+        self._arg_idx = arg_idx
+
+    def invoke_1(self, _rcvr):
+        raise NotImplementedError(
+            "Not supported, should never be called. We need an argument"
+        )
+
+    def invoke_2(self, rcvr, arg1):
+        rcvr.set_field(self._field_idx, arg1)
+        return rcvr
+
+    def invoke_3(self, rcvr, arg1, arg2):
+        if self._arg_idx == 1:
+            return self.invoke_2(rcvr, arg1)
+        return self.invoke_2(rcvr, arg2)
+
+    def invoke_n(self, stack, stack_ptr):
+        num_args = self._signature.get_number_of_signature_arguments()
+        rcvr = stack[stack_ptr - (num_args - 1)]
+        arg = stack[stack_ptr - (num_args - self._arg_idx)]
+        self.invoke_2(rcvr, arg)
+        return stack_pop_old_arguments_and_push_result(
+            stack,
+            stack_ptr,
+            num_args,
+            rcvr,
+        )

--- a/src/som/vmobjects/method_trivial.py
+++ b/src/som/vmobjects/method_trivial.py
@@ -1,7 +1,17 @@
-from rlib.jit import elidable_promote
+from rlib.jit import elidable_promote, unroll_safe
+from som.interpreter.ast.frame import FRAME_AND_INNER_RCVR_IDX
 from som.interpreter.bc.frame import stack_pop_old_arguments_and_push_result
+from som.interpreter.send import lookup_and_send_2
 
 from som.vmobjects.method import AbstractMethod
+
+
+@unroll_safe
+def determine_outer_self(rcvr, context_level):
+    outer_self = rcvr
+    for _ in range(0, context_level):
+        outer_self = outer_self.get_from_outer(FRAME_AND_INNER_RCVR_IDX)
+    return outer_self
 
 
 class AbstractTrivialMethod(AbstractMethod):
@@ -24,6 +34,8 @@ class AbstractTrivialMethod(AbstractMethod):
 
 
 class LiteralReturn(AbstractTrivialMethod):
+    _immutable_fields_ = ["_value"]
+
     def __init__(self, signature, value):
         AbstractTrivialMethod.__init__(self, signature)
         self._value = value
@@ -43,4 +55,80 @@ class LiteralReturn(AbstractTrivialMethod):
             stack_ptr,
             self._signature.get_number_of_signature_arguments(),
             self._value,
+        )
+
+
+class GlobalRead(AbstractTrivialMethod):
+    _immutable_fields_ = ["_assoc?", "_global_name", "_context_level", "universe"]
+
+    def __init__(self, signature, global_name, context_level, universe):
+        AbstractTrivialMethod.__init__(self, signature)
+        self._assoc = None
+        self._global_name = global_name
+        self._context_level = context_level
+
+        self.universe = universe
+
+    def invoke_1(self, rcvr):
+        if self._assoc is not None:
+            return self._assoc.value
+
+        if self.universe.has_global(self._global_name):
+            self._assoc = self.universe.get_globals_association(self._global_name)
+            return self._assoc.value
+
+        return lookup_and_send_2(
+            determine_outer_self(rcvr, self._context_level),
+            self._global_name,
+            "unknownGlobal:",
+        )
+
+    def invoke_2(self, rcvr, _arg1):
+        return self.invoke_1(rcvr)
+
+    def invoke_3(self, rcvr, _arg1, _arg2):
+        return self.invoke_1(rcvr)
+
+    def invoke_n(self, stack, stack_ptr):
+        num_args = self._signature.get_number_of_signature_arguments()
+        rcvr = stack[stack_ptr - (num_args - 1)]
+        value = self.invoke_1(rcvr)
+        return stack_pop_old_arguments_and_push_result(
+            stack,
+            stack_ptr,
+            num_args,
+            value,
+        )
+
+
+class FieldRead(AbstractTrivialMethod):
+    _immutable_fields_ = ["_field_idx", "_context_level"]
+
+    def __init__(self, signature, field_idx, context_level):
+        AbstractTrivialMethod.__init__(self, signature)
+        self._field_idx = field_idx
+        self._context_level = context_level
+
+    def invoke_1(self, rcvr):
+        if self._context_level == 0:
+            return rcvr.get_field(self._field_idx)
+
+        outer_self = determine_outer_self(rcvr, self._context_level)
+        return outer_self.get_field(self._field_idx)
+
+    def invoke_2(self, rcvr, _arg1):
+        return self.invoke_1(rcvr)
+
+    def invoke_3(self, rcvr, _arg1, _arg2):
+        return self.invoke_1(rcvr)
+
+    def invoke_n(self, stack, stack_ptr):
+        num_args = self._signature.get_number_of_signature_arguments()
+        rcvr = stack[stack_ptr - (num_args - 1)]
+        value = self.invoke_1(rcvr)
+        return stack_pop_old_arguments_and_push_result(
+            stack,
+            stack_ptr,
+            num_args,
+            value,
         )

--- a/src/som/vmobjects/method_trivial.py
+++ b/src/som/vmobjects/method_trivial.py
@@ -1,0 +1,46 @@
+from rlib.jit import elidable_promote
+from som.interpreter.bc.frame import stack_pop_old_arguments_and_push_result
+
+from som.vmobjects.method import AbstractMethod
+
+
+class AbstractTrivialMethod(AbstractMethod):
+    def get_number_of_locals(self):  # pylint: disable=no-self-use
+        return 0
+
+    def get_maximum_number_of_stack_elements(self):  # pylint: disable=no-self-use
+        return 0
+
+    def set_holder(self, value):
+        self._holder = value
+
+    @elidable_promote("all")
+    def get_number_of_arguments(self):
+        return self._signature.get_number_of_signature_arguments()
+
+    @elidable_promote("all")
+    def get_number_of_signature_arguments(self):
+        return self._signature.get_number_of_signature_arguments()
+
+
+class LiteralReturn(AbstractTrivialMethod):
+    def __init__(self, signature, value):
+        AbstractTrivialMethod.__init__(self, signature)
+        self._value = value
+
+    def invoke_1(self, _rcvr):
+        return self._value
+
+    def invoke_2(self, _rcvr, _arg1):
+        return self._value
+
+    def invoke_3(self, _rcvr, _arg1, _arg2):
+        return self._value
+
+    def invoke_n(self, stack, stack_ptr):
+        return stack_pop_old_arguments_and_push_result(
+            stack,
+            stack_ptr,
+            self._signature.get_number_of_signature_arguments(),
+            self._value,
+        )

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -192,6 +192,29 @@ def test_literal_return(mgenc, source, test_result):
     assert str(m.invoke_1(None)) == test_result
 
 
+@pytest.mark.parametrize("source", ["Nil", "true", "system", "MyClassFooBar"])
+def test_global_return(mgenc, source):
+    method_to_bytecodes(mgenc, "test = ( ^ " + source + " )")
+    assert mgenc.is_global_return()
+
+
+def test_field_getter_0(cgenc, mgenc):
+    add_field(cgenc, "field")
+    method_to_bytecodes(mgenc, "test = ( ^ field )")
+    assert mgenc.is_field_getter()
+
+
+def test_field_getter_n(cgenc, mgenc):
+    add_field(cgenc, "a")
+    add_field(cgenc, "b")
+    add_field(cgenc, "c")
+    add_field(cgenc, "d")
+    add_field(cgenc, "e")
+    add_field(cgenc, "field")
+    method_to_bytecodes(mgenc, "test = ( ^ field )")
+    assert mgenc.is_field_getter()
+
+
 def test_block_dup_pop_argument_pop(bgenc):
     bytecodes = block_to_bytecodes(bgenc, "[:arg | arg := 1. arg ]")
 

--- a/tests/test_optimize_trivial.py
+++ b/tests/test_optimize_trivial.py
@@ -1,0 +1,186 @@
+# pylint: disable=redefined-outer-name
+import pytest
+from rlib.string_stream import StringStream
+
+from som.compiler.bc.disassembler import dump_method
+from som.compiler.class_generation_context import ClassGenerationContext
+from som.interp_type import is_ast_interpreter
+from som.vm.current import current_universe
+from som.vmobjects.method_ast import AstMethod
+from som.vmobjects.method_bc import BcMethod
+from som.vmobjects.method_trivial import (
+    LiteralReturn,
+    GlobalRead,
+    FieldRead,
+    FieldWrite,
+)
+
+if is_ast_interpreter():
+    from som.compiler.ast.method_generation_context import MethodGenerationContext
+    from som.compiler.ast.parser import Parser
+else:
+    from som.compiler.bc.method_generation_context import MethodGenerationContext
+    from som.compiler.bc.parser import Parser
+
+
+def add_field(cgenc, name):
+    cgenc.add_instance_field(current_universe.symbol_for(name))
+
+
+def dump(mgenc):
+    dump_method(mgenc, "")
+
+
+@pytest.fixture
+def cgenc():
+    gen_c = ClassGenerationContext(current_universe)
+    gen_c.name = current_universe.symbol_for("Test")
+    return gen_c
+
+
+@pytest.fixture
+def mgenc(cgenc):
+    mgenc = MethodGenerationContext(current_universe, cgenc, None)
+    mgenc.add_argument("self")
+    return mgenc
+
+
+@pytest.fixture
+def bgenc(cgenc, mgenc):
+    bgenc = MethodGenerationContext(current_universe, cgenc, mgenc)
+    bgenc.add_argument("$blockSelf")
+    return bgenc
+
+
+def parse_method(mgenc, source):
+    parser = Parser(StringStream(source), "test", current_universe)
+    return parser.method(mgenc)
+
+
+def parse_block(bgenc, source):
+    parser = Parser(StringStream(source), "test", current_universe)
+    return parser.nested_block(bgenc)
+
+
+@pytest.mark.parametrize(
+    "source,test_result",
+    [
+        ("0", "0"),
+        ("1", "1"),
+        ("-10", "-10"),
+        ("3333", "3333"),
+        ("'str'", '"str"'),
+        ("#sym", "#sym"),
+        ("1.1", "1.1"),
+        ("-2342.234", "-2342.234"),
+        ("true", "true"),
+        ("false", "false"),
+        ("nil", "nil"),
+    ],
+)
+def test_literal_return(mgenc, source, test_result):
+    body_or_none = parse_method(mgenc, "test = ( ^ " + source + " )")
+    m = mgenc.assemble(body_or_none)
+    assert isinstance(m, LiteralReturn)
+    assert str(m.invoke_1(None)) == test_result
+
+
+@pytest.mark.parametrize("source", ["Nil", "system", "MyClassFooBar"])
+def test_global_return(mgenc, source):
+    body_or_none = parse_method(mgenc, "test = ( ^ " + source + " )")
+    m = mgenc.assemble(body_or_none)
+    assert isinstance(m, GlobalRead)
+
+
+def test_field_getter_0(cgenc, mgenc):
+    add_field(cgenc, "field")
+    body_or_none = parse_method(mgenc, "test = ( ^ field )")
+    m = mgenc.assemble(body_or_none)
+    assert isinstance(m, FieldRead)
+
+
+def test_field_getter_n(cgenc, mgenc):
+    add_field(cgenc, "a")
+    add_field(cgenc, "b")
+    add_field(cgenc, "c")
+    add_field(cgenc, "d")
+    add_field(cgenc, "e")
+    add_field(cgenc, "field")
+    body_or_none = parse_method(mgenc, "test = ( ^ field )")
+    m = mgenc.assemble(body_or_none)
+    assert isinstance(m, FieldRead)
+
+
+@pytest.mark.parametrize(
+    "source", ["field := val", "field := val.", "field := val. ^ self"]
+)
+def test_field_setter_0(cgenc, mgenc, source):
+    add_field(cgenc, "field")
+    body_or_none = parse_method(mgenc, "test: val = ( " + source + " )")
+    m = mgenc.assemble(body_or_none)
+    assert isinstance(m, FieldWrite)
+
+
+@pytest.mark.parametrize(
+    "source", ["field := value", "field := value.", "field := value. ^ self"]
+)
+def test_field_setter_n(cgenc, mgenc, source):
+    add_field(cgenc, "a")
+    add_field(cgenc, "b")
+    add_field(cgenc, "c")
+    add_field(cgenc, "d")
+    add_field(cgenc, "e")
+    add_field(cgenc, "field")
+    body_or_none = parse_method(mgenc, "test: value = ( " + source + " )")
+    m = mgenc.assemble(body_or_none)
+    assert isinstance(m, FieldWrite)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "0",
+        "1",
+        "-10",
+        "'str'",
+        "#sym",
+        "1.1",
+        "-2342.234",
+        "true",
+        "false",
+        "nil",
+    ],
+)
+def test_literal_no_return(mgenc, source):
+    body_or_none = parse_method(mgenc, "test = ( " + source + " )")
+    m = mgenc.assemble(body_or_none)
+    assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
+
+
+def test_block_return(mgenc):
+    body_or_none = parse_method(mgenc, "test = ( ^ [] )")
+    m = mgenc.assemble(body_or_none)
+    assert isinstance(m, AstMethod) or isinstance(m, BcMethod)
+
+
+@pytest.mark.parametrize(
+    "source,test_result",
+    [
+        ("0", "0"),
+        ("1", "1"),
+        ("-10", "-10"),
+        ("3333", "3333"),
+        ("'str'", '"str"'),
+        ("#sym", "#sym"),
+        ("1.1", "1.1"),
+        ("-2342.234", "-2342.234"),
+        ("true", "true"),
+        ("false", "false"),
+        ("nil", "nil"),
+    ],
+)
+def test_block_literal_return(bgenc, source, test_result):
+    body_or_none = parse_block(bgenc, "[ " + source + " ]")
+    m = bgenc.assemble(body_or_none)
+    assert isinstance(m, LiteralReturn)
+    assert str(m.invoke_1(None)) == test_result


### PR DESCRIPTION
Currently, trivial methods are:
- methods/blocks returning a literal
- methods/blocks returning a global
- methods/blocks returning value from a field
- methods that set a field from an argument (setters)

This change is a pretty good win.
NBody (AST startup) sees a 37% reduction in run time, Richards (AST startup) 22%.
NBody (BC startup) sees a 32% reduction in run time, Richards (BC startup) 15%.

Bounce on BC+JIT sees a 48% reduction in run time, Towers (BC+JIT) 21%.

The SomSom benchmarks see 8-10% reduction for the AST interpreter, and 16-21% for the bytecode interpreter.
https://rebench.stefan-marr.de/compare/RPySOM/1bb77ce0b2e9bd1b0250a4e51c3d67f57b702d68/705ede66bf7dc8338cb5380c7be1b982a78d5491

Pretty good results. This reduces the gap to 22-27% on the SomSom benchmarks.