### PR TITLE
Added --no-gc command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,18 @@ bytecode-based interpreter. One can choose between them with the `SOM_INTERP` en
 
 To check out the code, run:
 
-    git clone https://github.com/SOM-st/PySOM.git
+    git clone --recurse-submodules https://github.com/SOM-st/PySOM.git
+
+Note the `--recurse-submodules` option. It makes sure that the core library,
+i.e., the Smalltalk code is downloaded.
 
 PySOM's tests can be executed with:
 
-    ./som.sh -cp Smalltalk TestSuite/TestHarness.som
+    SOM_INTERP=AST ./som.sh -cp Smalltalk TestSuite/TestHarness.som
    
 A simple Hello World program can be started with:
 
-    ./som.sh -cp Smalltalk Examples/Hello/Hello.som
+    SOM_INTERP=AST ./som.sh -cp Smalltalk Examples/Hello.som
 
 To compile PySOM, a recent PyPy is recommended and the RPython source
 code is required. The source distribution of PyPy 7.3 can be used like this:

--- a/src/rlib/rgc.py
+++ b/src/rlib/rgc.py
@@ -1,7 +1,15 @@
 try:
     from rpython.rlib.rgc import collect  # pylint: disable=unused-import
+    from rpython.rlib.rgc import disable  # pylint: disable=unused-import
+    from rpython.rlib.rgc import isenabled  # pylint: disable=unused-import
 except ImportError:
     "NOT_RPYTHON"
 
     def collect():
         pass
+
+    def disable():
+        pass
+
+    def isenabled():
+        return 1

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -5,6 +5,7 @@ from rlib import jit
 from rlib.string_stream import encode_to_bytes
 from rlib.exit import Exit
 from rlib.osext import path_split
+from rlib import rgc
 
 from som.vmobjects.array import Array
 from som.vmobjects.block_bc import block_evaluation_primitive
@@ -162,6 +163,12 @@ class Universe(object):
                 self._dump_bytecodes = True
             elif arguments[i] in ["-h", "--help", "-?"] and not saw_others:
                 self._print_usage_and_exit()
+            elif arguments[i] == "--no-gc" and not saw_others:
+                rgc.disable()
+                if rgc.isenabled() == 0:
+                    print("GC successfully disabled.")
+                else:
+                    print("GC still enabled.")
             else:
                 saw_others = True
                 remaining_args.append(arguments[i])
@@ -204,6 +211,8 @@ class Universe(object):
         std_println("        set search path for application classes")
         std_println("    -d  enable disassembling")
         std_println("    -h  print this help")
+        std_println("")
+        std_println("    --no-gc disable garbage collection")
 
         # Exit
         self.exit(0)


### PR DESCRIPTION
This change adds the `--no-gc` option, which calls `rgc.disable()`.

It's tested with:

```Smaltalk
Hello = (
    run = ('Hello, World from SOM' println.
      1 to: 200000 do: [:i |
         | arr |
         arr := 1 to: 50000 ]
     )
)
```

It successfully blows up the heap size (too much for many systems... be warned).

@nanjekyejoannah this one is for you. This also fixes and closes #29.