### PR TITLE
Various fixes and improvements

### DIFF
--- a/src/rlib/string_stream.py
+++ b/src/rlib/string_stream.py
@@ -67,4 +67,4 @@ class StringStream(Stream):
         if self.pos == 0:
             self.pos = len(self._string)
             return self._string
-        return ""
+        return self.read(len(self._string) - self.pos)

--- a/src/som/compiler/ast/method_generation_context.py
+++ b/src/som/compiler/ast/method_generation_context.py
@@ -19,18 +19,6 @@ class MethodGenerationContext(MethodGenerationContextBase):
     def add_embedded_block_method(self, block_method):
         self._embedded_block_methods.append(block_method)
 
-    @staticmethod
-    def _add_argument_initialization(method_body):
-        return method_body
-        # TODO: see whether that has any for of benefit, or whether that is
-        # really just for the partial evaluator, that knows a certain pattern
-
-        # writes = [LocalVariableWriteNode(arg.get_frame_idx(),
-        #                                  ArgumentReadNode(arg.get_frame_idx()))
-        #           for arg in self._arguments.values()]
-        # return ArgumentInitializationNode(writes, method_body,
-        #                                   method_body.get_source_section())
-
     def assemble(self, method_body):
         if self._primitive:
             return empty_primitive(self.signature.get_embedded_string(), self.universe)
@@ -46,7 +34,6 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
         arg_inner_access, size_frame, size_inner = self.prepare_frame()
 
-        # method_body = self._add_argument_initialization(method_body)
         return AstMethod(
             self.signature,
             method_body,

--- a/src/som/compiler/ast/method_generation_context.py
+++ b/src/som/compiler/ast/method_generation_context.py
@@ -33,14 +33,14 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
     def assemble(self, method_body):
         if self._primitive:
-            return empty_primitive(self._signature.get_embedded_string(), self.universe)
+            return empty_primitive(self.signature.get_embedded_string(), self.universe)
 
         if self.needs_to_catch_non_local_returns:
             method_body = CatchNonLocalReturnNode(
                 method_body, method_body.source_section
             )
 
-        trivial_method = method_body.create_trivial_method(self._signature)
+        trivial_method = method_body.create_trivial_method(self.signature)
         if trivial_method is not None:
             return trivial_method
 
@@ -48,7 +48,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
         # method_body = self._add_argument_initialization(method_body)
         return AstMethod(
-            self._signature,
+            self.signature,
             method_body,
             arg_inner_access,
             size_frame,
@@ -65,7 +65,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
             identifier="%s>>#%s"
             % (
                 self.holder.name.get_embedded_string(),
-                self._signature.get_embedded_string(),
+                self.signature.get_embedded_string(),
             ),
             source_section=src_body,
         )

--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -1,5 +1,3 @@
-from rtruffle.source_section import SourceSection
-
 from som.compiler.ast.method_generation_context import MethodGenerationContext
 from som.compiler.parse_error import ParseError
 from som.compiler.parser import ParserBase
@@ -26,16 +24,6 @@ from som.vmobjects.string import String
 class Parser(ParserBase):
     def __init__(self, reader, file_name, universe):
         ParserBase.__init__(self, reader, file_name, universe)
-        self._source_reader = reader
-
-    def _get_source_section(self, coord):
-        return SourceSection(
-            self._source_reader,
-            "method",
-            coord,
-            self._lexer.get_number_of_characters_read(),
-            self._file_name,
-        )
 
     def _assign_source(self, node, coord):
         node.assign_source_section(self._get_source_section(coord))

--- a/src/som/compiler/ast/variable.py
+++ b/src/som/compiler/ast/variable.py
@@ -14,9 +14,10 @@ from som.interpreter.bc.bytecodes import Bytecodes
 
 class _Variable(object):
 
-    _immutable_fields_ = ["idx", "access_idx"]
+    _immutable_fields_ = ["idx", "access_idx", "source"]
 
-    def __init__(self, name, idx):
+    def __init__(self, name, idx, source):
+        self.source = source
         self._name = name
         self._is_accessed = False
         self._is_accessed_out_of_context = False
@@ -109,8 +110,8 @@ class _Variable(object):
 
 
 class Argument(_Variable):
-    def __init__(self, name, idx):
-        _Variable.__init__(self, name, idx)
+    def __init__(self, name, idx, source):
+        _Variable.__init__(self, name, idx, source)
         assert name == "self" or name == "$blockSelf" or idx >= 0
 
     def is_self(self):

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -68,10 +68,11 @@ def emit_push_field(mgenc, field_name):
 
 
 def emit_push_global(mgenc, glob):
+    idx = mgenc.add_literal_if_absent(glob)
     # the block needs to be able to send #unknownGlobal: to self
     if not mgenc.is_global_known(glob):
         mgenc.mark_self_as_accessed_from_outer_context()
-    _emit2(mgenc, BC.push_global, mgenc.find_literal_index(glob))
+    _emit2(mgenc, BC.push_global, idx)
 
 
 def emit_pop_argument(mgenc, idx, ctx):

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -2,41 +2,41 @@ from som.interpreter.bc.bytecodes import Bytecodes as BC
 
 
 def emit_inc(mgenc):
-    _emit1(mgenc, BC.inc)
+    emit1(mgenc, BC.inc)
 
 
 def emit_dec(mgenc):
-    _emit1(mgenc, BC.dec)
+    emit1(mgenc, BC.dec)
 
 
 def emit_pop(mgenc):
     if not mgenc.optimize_dup_pop_pop_sequence():
-        _emit1(mgenc, BC.pop)
+        emit1(mgenc, BC.pop)
 
 
 def emit_push_argument(mgenc, idx, ctx):
-    _emit3(mgenc, BC.push_argument, idx, ctx)
+    emit3(mgenc, BC.push_argument, idx, ctx)
 
 
 def emit_return_self(mgenc):
     mgenc.optimize_dup_pop_pop_sequence()
-    _emit1(mgenc, BC.return_self)
+    emit1(mgenc, BC.return_self)
 
 
 def emit_return_local(mgenc):
-    _emit1(mgenc, BC.return_local)
+    emit1(mgenc, BC.return_local)
 
 
 def emit_return_non_local(mgenc):
-    _emit2(mgenc, BC.return_non_local, mgenc.get_max_context_level())
+    emit2(mgenc, BC.return_non_local, mgenc.get_max_context_level())
 
 
 def emit_dup(mgenc):
-    _emit1(mgenc, BC.dup)
+    emit1(mgenc, BC.dup)
 
 
 def emit_push_block(mgenc, block_method, with_ctx):
-    _emit2(
+    emit2(
         mgenc,
         BC.push_block if with_ctx else BC.push_block_no_ctx,
         mgenc.find_literal_index(block_method),
@@ -44,7 +44,7 @@ def emit_push_block(mgenc, block_method, with_ctx):
 
 
 def emit_push_local(mgenc, idx, ctx):
-    _emit3(mgenc, BC.push_local, idx, ctx)
+    emit3(mgenc, BC.push_local, idx, ctx)
 
 
 def emit_push_field(mgenc, field_name):
@@ -53,13 +53,13 @@ def emit_push_field(mgenc, field_name):
 
     if ctx_level == 0:
         if field_idx == 0:
-            _emit1(mgenc, BC.push_field_0)
+            emit1(mgenc, BC.push_field_0)
             return
         if field_idx == 1:
-            _emit1(mgenc, BC.push_field_1)
+            emit1(mgenc, BC.push_field_1)
             return
 
-    _emit3(
+    emit3(
         mgenc,
         BC.push_field,
         mgenc.get_field_index(field_name),
@@ -72,15 +72,15 @@ def emit_push_global(mgenc, glob):
     # the block needs to be able to send #unknownGlobal: to self
     if not mgenc.is_global_known(glob):
         mgenc.mark_self_as_accessed_from_outer_context()
-    _emit2(mgenc, BC.push_global, idx)
+    emit2(mgenc, BC.push_global, idx)
 
 
 def emit_pop_argument(mgenc, idx, ctx):
-    _emit3(mgenc, BC.pop_argument, idx, ctx)
+    emit3(mgenc, BC.pop_argument, idx, ctx)
 
 
 def emit_pop_local(mgenc, idx, ctx):
-    _emit3(mgenc, BC.pop_local, idx, ctx)
+    emit3(mgenc, BC.pop_local, idx, ctx)
 
 
 def emit_pop_field(mgenc, field_name):
@@ -89,12 +89,12 @@ def emit_pop_field(mgenc, field_name):
 
     if ctx_level == 0:
         if field_idx == 0:
-            _emit1(mgenc, BC.pop_field_0)
+            emit1(mgenc, BC.pop_field_0)
             return
         if field_idx == 1:
-            _emit1(mgenc, BC.pop_field_1)
+            emit1(mgenc, BC.pop_field_1)
             return
-    _emit3(
+    emit3(
         mgenc,
         BC.pop_field,
         field_idx,
@@ -104,20 +104,20 @@ def emit_pop_field(mgenc, field_name):
 
 def emit_super_send(mgenc, msg):
     idx = mgenc.add_literal_if_absent(msg)
-    _emit2(mgenc, BC.super_send, idx)
+    emit2(mgenc, BC.super_send, idx)
 
 
 def emit_send(mgenc, msg):
     idx = mgenc.add_literal_if_absent(msg)
     num_args = msg.get_number_of_signature_arguments()
     if num_args == 1:
-        _emit2(mgenc, BC.send_1, idx)
+        emit2(mgenc, BC.send_1, idx)
     elif num_args == 2:
-        _emit2(mgenc, BC.send_2, idx)
+        emit2(mgenc, BC.send_2, idx)
     elif num_args == 3:
-        _emit2(mgenc, BC.send_3, idx)
+        emit2(mgenc, BC.send_3, idx)
     else:
-        _emit2(mgenc, BC.send_n, idx)
+        emit2(mgenc, BC.send_n, idx)
 
 
 def emit_push_constant(mgenc, lit):
@@ -126,44 +126,44 @@ def emit_push_constant(mgenc, lit):
 
     if isinstance(lit, Integer):
         if lit.get_embedded_integer() == 0:
-            _emit1(mgenc, BC.push_0)
+            emit1(mgenc, BC.push_0)
             return
         if lit.get_embedded_integer() == 1:
-            _emit1(mgenc, BC.push_1)
+            emit1(mgenc, BC.push_1)
             return
 
     if lit is nilObject:
-        _emit1(mgenc, BC.push_nil)
+        emit1(mgenc, BC.push_nil)
         return
 
     idx = mgenc.add_literal_if_absent(lit)
     if idx == 0:
-        _emit1(mgenc, BC.push_constant_0)
+        emit1(mgenc, BC.push_constant_0)
         return
     if idx == 1:
-        _emit1(mgenc, BC.push_constant_1)
+        emit1(mgenc, BC.push_constant_1)
         return
     if idx == 2:
-        _emit1(mgenc, BC.push_constant_2)
+        emit1(mgenc, BC.push_constant_2)
         return
 
-    _emit2(mgenc, BC.push_constant, idx)
+    emit2(mgenc, BC.push_constant, idx)
 
 
 def emit_push_constant_index(mgenc, lit_index):
-    _emit2(mgenc, BC.push_constant, lit_index)
+    emit2(mgenc, BC.push_constant, lit_index)
 
 
-def _emit1(mgenc, code):
+def emit1(mgenc, code):
     mgenc.add_bytecode(code)
 
 
-def _emit2(mgenc, code, idx):
+def emit2(mgenc, code, idx):
     mgenc.add_bytecode(code)
     mgenc.add_bytecode_argument(idx)
 
 
-def _emit3(mgenc, code, idx, ctx):
+def emit3(mgenc, code, idx, ctx):
     mgenc.add_bytecode(code)
     mgenc.add_bytecode_argument(idx)
     mgenc.add_bytecode_argument(ctx)

--- a/src/som/compiler/bc/disassembler.py
+++ b/src/som/compiler/bc/disassembler.py
@@ -86,11 +86,16 @@ def dump_bytecode(m, b, indent=""):
         dump_method(m.get_constant(b), indent + "\t")
     elif bytecode == Bytecodes.push_constant:
         constant = m.get_constant(b)
+        constant_class = constant.get_class(current_universe)
+        if constant_class:
+            class_name = str(constant_class.get_name())
+        else:
+            class_name = "not yet supported"
         error_println(
             "(index: "
             + str(m.get_bytecode(b + 1))
             + ") value: ("
-            + str(constant.get_class(current_universe).get_name())
+            + class_name
             + ") "
             + str(constant)
         )

--- a/src/som/compiler/bc/disassembler.py
+++ b/src/som/compiler/bc/disassembler.py
@@ -79,7 +79,12 @@ def dump_bytecode(m, b, indent=""):
         else:
             field_name = "Holder Not Set"
         error_println(
-            "(index: " + str(m.get_bytecode(b + 1)) + ") field: " + field_name
+            "(index: "
+            + str(m.get_bytecode(b + 1))
+            + ", context "
+            + str(m.get_bytecode(b + 2))
+            + ") field: "
+            + field_name
         )
     elif bytecode == Bytecodes.push_block:
         error_print("block: (index: " + str(m.get_bytecode(b + 1)) + ") ")

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -98,7 +98,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
     def assemble(self, _dummy):
         if self._primitive:
-            return empty_primitive(self._signature.get_embedded_string(), self.universe)
+            return empty_primitive(self.signature.get_embedded_string(), self.universe)
 
         trivial_method = self.assemble_trivial_method()
         if trivial_method is not None:
@@ -128,7 +128,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
             num_locals,
             max_stack_size,
             len(self._bytecode),
-            self._signature,
+            self.signature,
             arg_inner_access,
             size_frame,
             size_inner,
@@ -350,15 +350,15 @@ class MethodGenerationContext(MethodGenerationContextBase):
             return None
 
         if len(self._literals) == 1:
-            return LiteralReturn(self._signature, self._literals[0])
+            return LiteralReturn(self.signature, self._literals[0])
         if self._bytecode[0] == Bytecodes.push_0:
-            return LiteralReturn(self._signature, int_0)
+            return LiteralReturn(self.signature, int_0)
         if self._bytecode[0] == Bytecodes.push_1:
-            return LiteralReturn(self._signature, int_1)
+            return LiteralReturn(self.signature, int_1)
         if self._bytecode[0] == Bytecodes.push_nil:
             from som.vm.globals import nilObject
 
-            return LiteralReturn(self._signature, nilObject)
+            return LiteralReturn(self.signature, nilObject)
         raise NotImplementedError(
             "Not sure what's going on. Perhaps some new bytecode or unexpected literal?"
         )
@@ -378,16 +378,16 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
             glob = global_name.get_embedded_string()
             if glob == "true":
-                return LiteralReturn(self._signature, trueObject)
+                return LiteralReturn(self.signature, trueObject)
             if glob == "false":
-                return LiteralReturn(self._signature, falseObject)
+                return LiteralReturn(self.signature, falseObject)
             if glob == "nil":
                 from som.vm.globals import nilObject
 
-                return LiteralReturn(self._signature, nilObject)
+                return LiteralReturn(self.signature, nilObject)
 
             return GlobalRead(
-                self._signature,
+                self.signature,
                 global_name,
                 self.get_max_context_level(),
                 self.universe,
@@ -413,7 +413,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
             idx = self._bytecode[-3]
             ctx = self._bytecode[-2]
 
-        return FieldRead(self._signature, idx, ctx)
+        return FieldRead(self.signature, idx, ctx)
 
     def _assemble_field_setter(self, return_candidate):
         pop_candidate = self._last_bytecode_is_one_of(1, POP_FIELD_BYTECODES)
@@ -446,7 +446,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
             assert self._bytecode[-2] == 0
 
         arg_idx = self._bytecode[-(pop_len + return_len + 2)]
-        return FieldWrite(self._signature, field_idx, arg_idx)
+        return FieldWrite(self.signature, field_idx, arg_idx)
 
 
 class FindVarResult(object):

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -63,13 +63,13 @@ class MethodGenerationContext(MethodGenerationContextBase):
         # Get the constant associated to a given bytecode index
         return self._literals[self.get_bytecode(bytecode_index + 1)]
 
-    def add_argument(self, arg):
-        argument = MethodGenerationContextBase.add_argument(self, arg)
+    def add_argument(self, arg, source, parser):
+        argument = MethodGenerationContextBase.add_argument(self, arg, source, parser)
         self._arg_list.append(argument)
         return argument
 
-    def add_local(self, local):
-        local = MethodGenerationContextBase.add_local(self, local)
+    def add_local(self, local_name, source, parser):
+        local = MethodGenerationContextBase.add_local(self, local_name, source, parser)
         self._local_list.append(local)
         return local
 

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -314,7 +314,6 @@ class Parser(ParserBase):
         new_message = self.universe.symbol_for("new:")
         at_put_message = self.universe.symbol_for("at:put:")
 
-        mgenc.add_literal_if_absent(array_class_name)
         array_size_literal_idx = mgenc.add_literal(array_size_placeholder)
 
         # create empty array
@@ -376,7 +375,6 @@ class Parser(ParserBase):
                 mgenc.mark_self_as_accessed_from_outer_context()
             else:
                 globe = identifier
-                mgenc.add_literal_if_absent(globe)
                 emit_push_global(mgenc, globe)
 
     def _gen_pop_variable(self, mgenc, var):

--- a/src/som/compiler/method_generation_context.py
+++ b/src/som/compiler/method_generation_context.py
@@ -197,4 +197,4 @@ def _strip_colons_and_source_location(method_name):
 
     # replacing classic colons with triple colons to still indicate them without breaking
     # selector semantics based on colon counting
-    return name.replace(":", "⫶")
+    return name.replace(":", ";")

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -29,7 +29,6 @@ class ParserBase(object):
         Symbol.Comma,
         Symbol.At,
         Symbol.Per,
-        Symbol.NONE,
     ]
 
     _binary_op_syms = [
@@ -50,7 +49,6 @@ class ParserBase(object):
         Symbol.Comma,
         Symbol.At,
         Symbol.Per,
-        Symbol.NONE,
     ]
 
     _keyword_selector_syms = [Symbol.Keyword, Symbol.KeywordSequence]

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -177,10 +177,10 @@ class ParserBase(object):
             self._binary_pattern(mgenc)
 
     def _unary_pattern(self, mgenc):
-        mgenc.set_signature(self._unary_selector())
+        mgenc.signature = self._unary_selector()
 
     def _binary_pattern(self, mgenc):
-        mgenc.set_signature(self._binary_selector())
+        mgenc.signature = self._binary_selector()
         mgenc.add_argument_if_absent(self._argument())
 
     def _keyword_pattern(self, mgenc):
@@ -191,7 +191,7 @@ class ParserBase(object):
             keyword += self._keyword()
             mgenc.add_argument_if_absent(self._argument())
 
-        mgenc.set_signature(self.universe.symbol_for(keyword))
+        mgenc.signature = self.universe.symbol_for(keyword)
 
     def _unary_selector(self):
         return self.universe.symbol_for(self._identifier())
@@ -379,17 +379,6 @@ class ParserBase(object):
         if not self._lexer.peek_done:
             self._peek_for_next_symbol_from_lexer()
 
-    def _create_block_signature(self, mgenc):
-        block_sig = (
-            "$blockMethod@"
-            + str(self._lexer.line_number)
-            + "@"
-            + str(self._lexer.get_current_column())
-        )
-        arg_size = mgenc.get_number_of_arguments()
-        block_sig += ":" * (arg_size - 1)
-        return self.universe.symbol_for(block_sig)
-
     def _nested_block_signature(self, mgenc):
         self._expect(Symbol.NewBlock)
 
@@ -398,4 +387,6 @@ class ParserBase(object):
         if self._sym == Symbol.Colon:
             self._block_pattern(mgenc)
 
-        mgenc.set_signature(self._create_block_signature(mgenc))
+        mgenc.set_block_signature(
+            self._lexer.line_number, self._lexer.get_current_column()
+        )

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -63,6 +63,10 @@ class Universe(object):
         "double_layout?",
         "_symbol_table",
         "_globals",
+        "start_time",
+        "sym_plus",
+        "sym_minus",
+        "sym_nil",
         "_object_system_initialized",
     ]
 
@@ -94,9 +98,9 @@ class Universe(object):
         self.double_class = None
         self.double_layout = None
 
-        self.sym_nil = None
-        self.sym_plus = None
-        self.sym_minus = None
+        self.sym_nil = self.symbol_for("nil")
+        self.sym_plus = self.symbol_for("+")
+        self.sym_minus = self.symbol_for("-")
 
         self._last_exit_code = 0
         self._avoid_exit = avoid_exit
@@ -297,10 +301,6 @@ class Universe(object):
         # Load the system class and create an instance of it
         self.system_class = self.load_class(self.symbol_for("System"))
         system_object = self.new_instance(self.system_class)
-
-        self.sym_nil = self.symbol_for("nil")
-        self.sym_plus = self.symbol_for("+")
-        self.sym_minus = self.symbol_for("+")
 
         # Put special objects and classes into the dictionary of globals
         self.set_global(self.sym_nil, nilObject)

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -57,6 +57,22 @@ def block_to_bytecodes(bgenc, source):
     return bgenc.get_bytecodes()
 
 
+@pytest.mark.parametrize(
+    "operator,bytecode",
+    [
+        ("+", Bytecodes.inc),
+        ("-", Bytecodes.dec),
+    ],
+)
+def test_inc_dec_bytecodes(mgenc, operator, bytecode):
+    bytecodes = method_to_bytecodes(mgenc, "test = ( 1 OP 1 )".replace("OP", operator))
+
+    assert len(bytecodes) == 3
+    assert bytecodes[0] == Bytecodes.push_1
+    assert bytecodes[1] == bytecode
+    assert bytecodes[2] == Bytecodes.return_self
+
+
 def test_empty_method_returns_self(mgenc):
     bytecodes = method_to_bytecodes(mgenc, "test = ( )")
 

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -33,7 +33,7 @@ def cgenc():
 @pytest.fixture
 def mgenc(cgenc):
     mgenc = MethodGenerationContext(current_universe, cgenc, None)
-    mgenc.add_argument("self")
+    mgenc.add_argument("self", None, None)
     return mgenc
 
 
@@ -41,7 +41,6 @@ def mgenc(cgenc):
 def bgenc(cgenc, mgenc):
     mgenc.signature = current_universe.symbol_for("test")
     bgenc = MethodGenerationContext(current_universe, cgenc, mgenc)
-    bgenc.add_argument("$blockSelf")
     return bgenc
 
 

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -39,6 +39,7 @@ def mgenc(cgenc):
 
 @pytest.fixture
 def bgenc(cgenc, mgenc):
+    mgenc.signature = current_universe.symbol_for("test")
     bgenc = MethodGenerationContext(current_universe, cgenc, mgenc)
     bgenc.add_argument("$blockSelf")
     return bgenc

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -171,7 +171,7 @@ def test_send_dup_pop_field_return_local_period(cgenc, mgenc):
     assert Bytecodes.return_local == bytecodes[7]
 
 
-def test_block_dup_pop_argument_pop(bgenc):
+def test_block_dup_pop_argument_pop_return_arg(bgenc):
     bytecodes = block_to_bytecodes(bgenc, "[:arg | arg := 1. arg ]")
 
     assert len(bytecodes) == 8
@@ -181,7 +181,7 @@ def test_block_dup_pop_argument_pop(bgenc):
     assert Bytecodes.return_local == bytecodes[7]
 
 
-def test_block_dup_pop_argument_pop_implicit_return_self(bgenc):
+def test_block_dup_pop_argument_pop_implicit_return(bgenc):
     bytecodes = block_to_bytecodes(bgenc, "[:arg | arg := 1 ]")
 
     assert len(bytecodes) == 6
@@ -191,7 +191,7 @@ def test_block_dup_pop_argument_pop_implicit_return_self(bgenc):
     assert Bytecodes.return_local == bytecodes[5]
 
 
-def test_block_dup_pop_argument_pop_implicit_return_self_dot(bgenc):
+def test_block_dup_pop_argument_pop_implicit_return_dot(bgenc):
     bytecodes = block_to_bytecodes(bgenc, "[:arg | arg := 1. ]")
 
     assert len(bytecodes) == 6

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -45,7 +45,7 @@ def bgenc(cgenc, mgenc):
 
 
 def method_to_bytecodes(mgenc, source):
-    parser = Parser(StringStream(source), "test", current_universe)
+    parser = Parser(StringStream(source.strip()), "test", current_universe)
     parser.method(mgenc)
     return mgenc.get_bytecodes()
 

--- a/tests/test_optimize_trivial.py
+++ b/tests/test_optimize_trivial.py
@@ -42,6 +42,7 @@ def cgenc():
 def mgenc(cgenc):
     mgenc = MethodGenerationContext(current_universe, cgenc, None)
     mgenc.add_argument("self")
+    mgenc.signature = current_universe.symbol_for("test")
     return mgenc
 
 

--- a/tests/test_optimize_trivial.py
+++ b/tests/test_optimize_trivial.py
@@ -41,7 +41,7 @@ def cgenc():
 @pytest.fixture
 def mgenc(cgenc):
     mgenc = MethodGenerationContext(current_universe, cgenc, None)
-    mgenc.add_argument("self")
+    mgenc.add_argument("self", None, None)
     mgenc.signature = current_universe.symbol_for("test")
     return mgenc
 
@@ -49,7 +49,6 @@ def mgenc(cgenc):
 @pytest.fixture
 def bgenc(cgenc, mgenc):
     bgenc = MethodGenerationContext(current_universe, cgenc, mgenc)
-    bgenc.add_argument("$blockSelf")
     return bgenc
 
 


### PR DESCRIPTION
This is a random collection of little things.
It starts with fixing the `readline()` function in the string stream, making the disassembler more robust to fixing the `DEC` bytecode optimization, which wasn't triggering because the `sym_minus` was initialized as a `+`. Oops...

This also improves the names of blocks to encode the name of the outer method.

Variables keeps track of the source location where it was defined.