### PR TITLE
Implement inlining of #ifTrue:*/#ifFalse:* messages

### DIFF
--- a/src/rlib/min_heap_queue.py
+++ b/src/rlib/min_heap_queue.py
@@ -1,0 +1,56 @@
+# Verbatim copy basic heapq operations, only change is inlining <
+# This is the version of Python 2.7
+
+
+def heappush(heap, item):
+    """Push item onto heap, maintaining the heap invariant."""
+    heap.append(item)
+    _siftdown(heap, 0, len(heap) - 1)
+
+
+def heappop(heap):
+    """Pop the smallest item off the heap, maintaining the heap invariant."""
+    lastelt = heap.pop()  # raises appropriate IndexError if heap is empty
+    if heap:
+        returnitem = heap[0]
+        heap[0] = lastelt
+        _siftup(heap, 0)
+    else:
+        returnitem = lastelt
+    return returnitem
+
+
+def _siftdown(heap, startpos, pos):
+    newitem = heap[pos]
+    # Follow the path to the root, moving parents down until finding a place
+    # newitem fits.
+    while pos > startpos:
+        parentpos = (pos - 1) >> 1
+        parent = heap[parentpos]
+        if newitem[0] < parent[0]:
+            heap[pos] = parent
+            pos = parentpos
+            continue
+        break
+    heap[pos] = newitem
+
+
+def _siftup(heap, pos):
+    endpos = len(heap)
+    startpos = pos
+    newitem = heap[pos]
+    # Bubble up the smaller child until hitting a leaf.
+    childpos = 2 * pos + 1  # leftmost child position
+    while childpos < endpos:
+        # Set childpos to index of smaller child.
+        rightpos = childpos + 1
+        if rightpos < endpos and not heap[childpos][0] < heap[rightpos][0]:
+            childpos = rightpos
+        # Move the smaller child up.
+        heap[pos] = heap[childpos]
+        pos = childpos
+        childpos = 2 * pos + 1
+    # The leaf at pos is empty now.  Put newitem there, and bubble it up
+    # to its final resting place (by sifting its parents down).
+    heap[pos] = newitem
+    _siftdown(heap, startpos, pos)

--- a/src/rlib/min_heap_queue.py
+++ b/src/rlib/min_heap_queue.py
@@ -1,5 +1,8 @@
 # Verbatim copy basic heapq operations, only change is inlining <
 # This is the version of Python 2.7
+# https://github.com/python/cpython/blob/8d21aa21f2cbc6d50aab3f420bb23be1d081dac4/Lib/heapq.py
+# For the license of this file, see Python License v2
+# https://github.com/python/cpython/blob/main/LICENSE
 
 
 def heappush(heap, item):

--- a/src/rtruffle/abstract_node.py
+++ b/src/rtruffle/abstract_node.py
@@ -5,13 +5,15 @@ class AbstractNode(object):
     pass
 
 
-def _get_all_child_fields(cls):
+def _get_all_child_fields(clazz):
+    cls = clazz
     field_names = []
     while cls is not AbstractNode:
         if hasattr(cls, "_child_nodes_"):
             field_names += cls._child_nodes_  # pylint: disable=protected-access
         cls = cls.__base__
-    return field_names
+
+    return set(field_names)
 
 
 def _generate_replace_method(cls):
@@ -47,6 +49,46 @@ def _generate_replace_method(cls):
     cls.replace_child_with = _replace_child_with
 
 
+def _generate_adapt_after_inlining(cls):
+    child_fields = unrolling_iterable(_get_all_child_fields(cls))
+
+    def _adapt_after_inlining(node, mgenc):
+        for child_slot in child_fields:
+            if child_slot.endswith("[*]"):
+                slot_name = child_slot[:-3]
+                nodes = getattr(node, slot_name)
+                if nodes:
+                    for n in nodes:
+                        n.adapt_after_inlining(mgenc)
+            else:
+                current = getattr(node, child_slot)
+                current.adapt_after_inlining(mgenc)
+        node.handle_inlining(mgenc)
+
+    cls.adapt_after_inlining = _adapt_after_inlining
+
+
+def _generate_adapt_after_outer_inlined(cls):
+    child_fields = unrolling_iterable(_get_all_child_fields(cls))
+
+    def _adapt_after_outer_inlined(node, removed_ctx_level, mgenc_with_inlined):
+        for child_slot in child_fields:
+            if child_slot.endswith("[*]"):
+                slot_name = child_slot[:-3]
+                nodes = getattr(node, slot_name)
+                if nodes:
+                    for n in nodes:
+                        n.adapt_after_outer_inlined(
+                            removed_ctx_level, mgenc_with_inlined
+                        )
+            else:
+                current = getattr(node, child_slot)
+                current.adapt_after_outer_inlined(removed_ctx_level, mgenc_with_inlined)
+        node.handle_outer_inlined(removed_ctx_level, mgenc_with_inlined)
+
+    cls.adapt_after_outer_inlined = _adapt_after_outer_inlined
+
+
 class NodeInitializeMetaClass(type):
     def __init__(cls, name, bases, dic):
         type.__init__(cls, name, bases, dic)
@@ -54,3 +96,5 @@ class NodeInitializeMetaClass(type):
 
     def _initialize_node_class(cls):
         _generate_replace_method(cls)
+        _generate_adapt_after_inlining(cls)
+        _generate_adapt_after_outer_inlined(cls)

--- a/src/som/compiler/ast/method_generation_context.py
+++ b/src/som/compiler/ast/method_generation_context.py
@@ -43,6 +43,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
             # copy list to make it immutable for RPython
             self._embedded_block_methods[:],
             self._get_source_section_for_method(method_body),
+            self.lexical_scope,
         )
 
     def _get_source_section_for_method(self, expr):

--- a/src/som/compiler/ast/variable.py
+++ b/src/som/compiler/ast/variable.py
@@ -108,6 +108,15 @@ class _Variable(object):
                 return Bytecodes.pop_frame_2
         return Bytecodes.pop_frame
 
+    def get_qualified_name(self):
+        return (
+            self._name
+            + ":"
+            + str(self.source.coord.start_line)
+            + ":"
+            + str(self.source.coord.start_column)
+        )
+
 
 class Argument(_Variable):
     def __init__(self, name, idx, source):
@@ -136,6 +145,18 @@ class Argument(_Variable):
             return LocalFrameVarReadNode(FRAME_AND_INNER_RCVR_IDX, source_section)
         return _Variable.get_initialized_read_node(self, context_level, source_section)
 
+    def copy_for_inlining(self, idx):
+        if self._name == "$blockSelf":
+            return None
+        return Argument(self._name, idx, self.source)
+
+    def __str__(self):
+        return "Argument(" + self._name + " idx: " + str(self.idx) + ")"
+
 
 class Local(_Variable):
-    pass
+    def copy_for_inlining(self, idx):
+        return Local(self._name, idx, self.source)
+
+    def __str__(self):
+        return "Local(" + self._name + " idx: " + str(self.idx) + ")"

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -36,10 +36,11 @@ def emit_dup(mgenc):
 
 
 def emit_push_block(mgenc, block_method, with_ctx):
+    idx = mgenc.add_literal_if_absent(block_method)
     emit2(
         mgenc,
         BC.push_block if with_ctx else BC.push_block_no_ctx,
-        mgenc.find_literal_index(block_method),
+        idx,
     )
 
 

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -155,6 +155,20 @@ def emit_push_constant_index(mgenc, lit_index):
     emit2(mgenc, BC.push_constant, lit_index)
 
 
+def emit_jump_on_bool_with_dummy_offset(mgenc, is_if_true, needs_pop):
+    # Remember: true and false seem flipped here.
+    # This is because if the test passes, the block is inlined directly.
+    # But if the test fails, we need to jump.
+    # Thus, an  `#ifTrue:` needs to generated a jump_on_false.
+    if is_if_true:
+        emit1(mgenc, BC.jump_on_false_pop if needs_pop else BC.jump_on_false_top_nil)
+    else:
+        emit1(mgenc, BC.jump_on_true_pop if needs_pop else BC.jump_on_true_top_nil)
+
+    idx = mgenc.add_bytecode_argument_and_get_index(0)
+    return idx
+
+
 def emit1(mgenc, code):
     mgenc.add_bytecode(code)
 

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -52,6 +52,10 @@ def emit_push_field(mgenc, field_name):
     ctx_level = mgenc.get_max_context_level()
     field_idx = mgenc.get_field_index(field_name)
 
+    emit_push_field_with_index(mgenc, field_idx, ctx_level)
+
+
+def emit_push_field_with_index(mgenc, field_idx, ctx_level):
     if ctx_level == 0:
         if field_idx == 0:
             emit1(mgenc, BC.push_field_0)
@@ -63,7 +67,7 @@ def emit_push_field(mgenc, field_name):
     emit3(
         mgenc,
         BC.push_field,
-        mgenc.get_field_index(field_name),
+        field_idx,
         mgenc.get_max_context_level(),
     )
 
@@ -87,7 +91,10 @@ def emit_pop_local(mgenc, idx, ctx):
 def emit_pop_field(mgenc, field_name):
     ctx_level = mgenc.get_max_context_level()
     field_idx = mgenc.get_field_index(field_name)
+    emit_pop_field_with_index(mgenc, field_idx, ctx_level)
 
+
+def emit_pop_field_with_index(mgenc, field_idx, ctx_level):
     if ctx_level == 0:
         if field_idx == 0:
             emit1(mgenc, BC.pop_field_0)

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -169,6 +169,12 @@ def emit_jump_on_bool_with_dummy_offset(mgenc, is_if_true, needs_pop):
     return idx
 
 
+def emit_jump_with_dummy_offset(mgenc):
+    emit1(mgenc, BC.jump)
+    idx = mgenc.add_bytecode_argument_and_get_index(0)
+    return idx
+
+
 def emit1(mgenc, code):
     mgenc.add_bytecode(code)
 

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -184,6 +184,11 @@ def emit2(mgenc, code, idx):
     mgenc.add_bytecode_argument(idx)
 
 
+def emit2_with_dummy(mgenc, code):
+    mgenc.add_bytecode(code)
+    return mgenc.add_bytecode_argument_and_get_index(0)
+
+
 def emit3(mgenc, code, idx, ctx):
     mgenc.add_bytecode(code)
     mgenc.add_bytecode_argument(idx)

--- a/src/som/compiler/bc/disassembler.py
+++ b/src/som/compiler/bc/disassembler.py
@@ -100,9 +100,10 @@ def dump_bytecode(m, b, indent=""):
             "(index: "
             + str(m.get_bytecode(b + 1))
             + ") value: ("
+            + str(constant)
+            + " class: "
             + class_name
             + ") "
-            + str(constant)
         )
     elif bytecode == Bytecodes.push_global:
         error_println(

--- a/src/som/compiler/bc/disassembler.py
+++ b/src/som/compiler/bc/disassembler.py
@@ -1,6 +1,12 @@
 from som.vm.current import current_universe
 from som.vm.universe import error_print, error_println
-from som.interpreter.bc.bytecodes import bytecode_as_str, bytecode_length, Bytecodes
+from som.interpreter.bc.bytecodes import (
+    bytecode_as_str,
+    bytecode_length,
+    Bytecodes,
+    is_one_of,
+    JUMP_BYTECODES,
+)
 
 
 def dump(clazz):
@@ -142,6 +148,13 @@ def dump_bytecode(m, b, indent=""):
             + str(m.get_bytecode(b + 1))
             + ", context "
             + str(m.get_bytecode(b + 2))
+        )
+    elif bytecode == Bytecodes.return_non_local:
+        error_println("context: " + str(m.get_bytecode(b + 1)))
+    elif is_one_of(bytecode, JUMP_BYTECODES):
+        offset = m.get_bytecode(b + 1)
+        error_println(
+            "(jump offset: " + str(offset) + " -> jump target: " + str(b + offset) + ")"
         )
     else:
         error_println("<incorrect bytecode>")

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -167,9 +167,10 @@ class MethodGenerationContext(MethodGenerationContextBase):
             return self.outer_genc.get_local(index, context - 1)
         return self._local_list[index]
 
-    def get_inlined_local_idx(self, var):
+    def get_inlined_local_idx(self, var, ctx_level):
         for i in range(len(self._local_list) - 1, -1, -1):
             if self._local_list[i].source is var.source:
+                self._local_list[i].mark_accessed(ctx_level)
                 return i
         raise Exception(
             "Unexpected issue trying to find an inlined variable. "

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -515,7 +515,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
         self._is_currently_inlining_a_block = True
         to_be_inlined.inline(self)
 
-        self._patch_jump_offset_to_point_to_next_instruction(
+        self.patch_jump_offset_to_point_to_next_instruction(
             jump_offset_idx_to_skip_true_branch, parser
         )
 
@@ -564,7 +564,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
         jump_offset_idx_to_skip_false_branch = emit_jump_with_dummy_offset(self)
 
-        self._patch_jump_offset_to_point_to_next_instruction(
+        self.patch_jump_offset_to_point_to_next_instruction(
             jump_offset_idx_to_skip_true_branch, parser
         )
 
@@ -574,7 +574,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
         to_be_inlined_2.inline(self)
         self._is_currently_inlining_a_block = False
 
-        self._patch_jump_offset_to_point_to_next_instruction(
+        self.patch_jump_offset_to_point_to_next_instruction(
             jump_offset_idx_to_skip_false_branch, parser
         )
 
@@ -583,7 +583,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
         return True
 
-    def _patch_jump_offset_to_point_to_next_instruction(self, idx_of_offset, parser):
+    def patch_jump_offset_to_point_to_next_instruction(self, idx_of_offset, parser):
         instruction_start = idx_of_offset - 1
         bytecode = self._bytecode[instruction_start]
         assert is_one_of(bytecode, JUMP_BYTECODES)

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -598,7 +598,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
     def _check_jump_offset(parser, jump_offset, bytecode):
         from som.compiler.symbol import Symbol
 
-        if not -128 <= jump_offset <= 127:
+        if not 0 <= jump_offset < 256:
             raise ParseError(
                 "The jump_offset for the "
                 + bytecode_as_str(bytecode)

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -608,12 +608,6 @@ class MethodGenerationContext(MethodGenerationContextBase):
                 parser,
             )
 
-    def merge_into_scope(self, scope_to_be_inlined):
-        assert len(scope_to_be_inlined.arguments) == 1
-        local_vars = scope_to_be_inlined.locals
-        if local_vars:
-            self.inline_locals(local_vars)
-
 
 class FindVarResult(object):
     def __init__(self, var, context, is_argument):

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -523,13 +523,15 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
     @staticmethod
     def _check_jump_offset(parser, jump_offset, bytecode):
+        from som.compiler.symbol import Symbol
+
         if not -128 <= jump_offset <= 127:
             raise ParseError(
                 "The jump_offset for the "
                 + bytecode_as_str(bytecode)
                 + " bytecode is out of range: "
                 + str(jump_offset),
-                None,
+                Symbol.NONE,
                 parser,
             )
 

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -246,6 +246,13 @@ class Parser(ParserBase):
             keyword += self._keyword()
             self._formula(mgenc)
 
+        if not is_super_send and (
+            keyword == "ifTrue:"
+            and mgenc.inline_if_true_or_if_false(self, True)
+            or (keyword == "ifFalse:" and mgenc.inline_if_true_or_if_false(self, False))
+        ):
+            return
+
         msg = self.universe.symbol_for(keyword)
 
         if is_super_send:

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -239,12 +239,14 @@ class Parser(ParserBase):
         is_super_send = self._super_send
         self._super_send = False
 
-        keyword = self._keyword()
+        keyword_parts = [self._keyword()]
         self._formula(mgenc)
 
         while self._sym == Symbol.Keyword:
-            keyword += self._keyword()
+            keyword_parts.append(self._keyword())
             self._formula(mgenc)
+
+        keyword = "".join(keyword_parts)
 
         if not is_super_send and (
             (keyword == "ifTrue:" and mgenc.inline_if_true_or_if_false(self, True))

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -247,9 +247,12 @@ class Parser(ParserBase):
             self._formula(mgenc)
 
         if not is_super_send and (
-            keyword == "ifTrue:"
-            and mgenc.inline_if_true_or_if_false(self, True)
+            (keyword == "ifTrue:" and mgenc.inline_if_true_or_if_false(self, True))
             or (keyword == "ifFalse:" and mgenc.inline_if_true_or_if_false(self, False))
+            or (keyword == "ifTrue:ifFalse:" and mgenc.inline_if_true_false(self, True))
+            or (
+                keyword == "ifFalse:ifTrue:" and mgenc.inline_if_true_false(self, False)
+            )
         ):
             return
 

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -159,7 +159,6 @@ class Parser(ParserBase):
             self.nested_block(bgenc)
 
             block_method = bgenc.assemble(None)
-            mgenc.add_literal(block_method)
             emit_push_block(mgenc, block_method, bgenc.requires_context())
         else:
             self._literal(mgenc)

--- a/src/som/compiler/lexical_scope.py
+++ b/src/som/compiler/lexical_scope.py
@@ -1,17 +1,50 @@
+from rlib.debug import make_sure_not_resized
+
+
 class LexicalScope(object):
-    _immutable_fields_ = ["_outer", "arguments[*]", "locals[*]"]
+    _immutable_fields_ = ["outer", "arguments[*]", "locals[*]"]
 
     def __init__(self, outer, arguments, local_vars):
-        self._outer = outer
+        self.outer = outer
         self.arguments = arguments
         self.locals = local_vars
+        assert self.locals is not None
+        assert self.arguments is not None
 
     def get_argument(self, idx, ctx_level):
         if ctx_level > 0:
-            return self._outer.get_argument(idx, ctx_level - 1)
+            return self.outer.get_argument(idx, ctx_level - 1)
         return self.arguments[idx]
 
     def get_local(self, idx, ctx_level):
+        assert self.locals is not None
         if ctx_level > 0:
-            return self._outer.get_local(idx, ctx_level - 1)
+            return self.outer.get_local(idx, ctx_level - 1)
         return self.locals[idx]
+
+    def add_inlined_locals(self, local_vars):
+        if not local_vars:
+            return
+
+        combined = [None] * (len(self.locals) + len(local_vars))
+
+        i = 0
+        for local in self.locals:
+            combined[i] = local
+            i += 1
+
+        for local in local_vars:
+            combined[i] = local
+            i += 1
+
+        self.locals = combined
+        make_sure_not_resized(self.locals)
+
+    def drop_inlined_scope(self):
+        """
+        This removes the inlined scope from the chain.
+        Removal is done exactly once, after all embedded blocks
+        were adapted.
+        """
+        assert self.outer.outer
+        self.outer = self.outer.outer

--- a/src/som/compiler/method_generation_context.py
+++ b/src/som/compiler/method_generation_context.py
@@ -82,6 +82,20 @@ class MethodGenerationContextBase(object):
         self._locals[local_name] = result
         return result
 
+    def inline_locals(self, local_vars):
+        fresh_copies = []
+        for local in local_vars:
+            fresh_copy = local.copy_for_inlining(len(self._locals))
+            if fresh_copy:
+                # fresh_copy can be None, because we don't need the $blockSelf
+                name = local.get_qualified_name()
+                assert name not in self._locals
+                self._locals[name] = fresh_copy
+                fresh_copies.append(fresh_copy)
+
+        self.lexical_scope.add_inlined_locals(fresh_copies)
+        return fresh_copies
+
     def complete_lexical_scope(self):
         self.lexical_scope = LexicalScope(
             self.outer_genc.lexical_scope if self.outer_genc else None,

--- a/src/som/compiler/method_generation_context.py
+++ b/src/som/compiler/method_generation_context.py
@@ -96,6 +96,17 @@ class MethodGenerationContextBase(object):
         self.lexical_scope.add_inlined_locals(fresh_copies)
         return fresh_copies
 
+    def get_inlined_local(self, var, ctx_level):
+        for local in self._locals.values():
+            if local.source is var.source:
+                local.mark_accessed(ctx_level)
+                return local
+        raise Exception(
+            "Unexpected issue trying to find an inlined variable. "
+            + str(var)
+            + " could not be found."
+        )
+
     def complete_lexical_scope(self):
         self.lexical_scope = LexicalScope(
             self.outer_genc.lexical_scope if self.outer_genc else None,
@@ -199,6 +210,12 @@ class MethodGenerationContextBase(object):
             block_sig += ":"
 
         self.signature = self.universe.symbol_for(block_sig)
+
+    def merge_into_scope(self, scope_to_be_inlined):
+        assert len(scope_to_be_inlined.arguments) == 1
+        local_vars = scope_to_be_inlined.locals
+        if local_vars:
+            self.inline_locals(local_vars)
 
 
 def _strip_colons_and_source_location(method_name):

--- a/src/som/interpreter/ast/nodes/block_node.py
+++ b/src/som/interpreter/ast/nodes/block_node.py
@@ -17,6 +17,9 @@ class BlockNode(LiteralNode):
     def create_trivial_method(self, signature):
         return None
 
+    def get_method(self):
+        return self._value
+
 
 class BlockNodeWithContext(BlockNode):
     def __init__(self, value, universe, source_section=None):
@@ -24,3 +27,9 @@ class BlockNodeWithContext(BlockNode):
 
     def execute(self, frame):
         return AstBlock(self._value, get_inner_as_context(frame))
+
+    def handle_inlining(self, mgenc):
+        self._value.adapt_after_outer_inlined(1, mgenc)
+
+    def handle_outer_inlined(self, removed_ctx_level, mgenc_with_inlined):
+        self._value.adapt_after_outer_inlined(removed_ctx_level + 1, mgenc_with_inlined)

--- a/src/som/interpreter/ast/nodes/expression_node.py
+++ b/src/som/interpreter/ast/nodes/expression_node.py
@@ -10,3 +10,11 @@ class ExpressionNode(Node):
 
     def is_trivial_in_sequence(self):  # pylint: disable=no-self-use
         return False
+
+    def handle_inlining(self, mgenc):  # pylint: disable=W
+        pass
+
+    def handle_outer_inlined(
+        self, removed_ctx_level, mgenc_with_inlined
+    ):  # pylint: disable=W
+        pass

--- a/src/som/interpreter/ast/nodes/global_read_node.py
+++ b/src/som/interpreter/ast/nodes/global_read_node.py
@@ -55,6 +55,9 @@ class _UninitializedGlobalReadNode(ContextualNode):
             signature, self._global_name, self._context_level, self.universe
         )
 
+    def handle_inlining(self, mgenc):
+        self._context_level -= 1
+
 
 class _CachedGlobalReadNode(ExpressionNode):
 

--- a/src/som/interpreter/ast/nodes/literal_node.py
+++ b/src/som/interpreter/ast/nodes/literal_node.py
@@ -1,5 +1,4 @@
 from som.interpreter.ast.nodes.expression_node import ExpressionNode
-from som.vmobjects.method_trivial import LiteralReturn
 
 
 class LiteralNode(ExpressionNode):
@@ -14,4 +13,6 @@ class LiteralNode(ExpressionNode):
         return self._value
 
     def create_trivial_method(self, signature):
+        from som.vmobjects.method_trivial import LiteralReturn
+
         return LiteralReturn(signature, self._value)

--- a/src/som/interpreter/ast/nodes/message/generic_node.py
+++ b/src/som/interpreter/ast/nodes/message/generic_node.py
@@ -13,7 +13,7 @@ from som.interpreter.ast.nodes.expression_node import ExpressionNode
 class _AbstractGenericMessageNode(ExpressionNode):
 
     _immutable_fields_ = ["_selector", "_dispatch?", "_rcvr_expr?", "universe"]
-    _child_nodes_ = ["_dispatch", "_rcvr_expr"]
+    _child_nodes_ = ["_rcvr_expr"]
 
     def __init__(self, selector, universe, rcvr_expr, source_section=None):
         ExpressionNode.__init__(self, source_section)

--- a/src/som/interpreter/ast/nodes/specialized/literal_if.py
+++ b/src/som/interpreter/ast/nodes/specialized/literal_if.py
@@ -1,0 +1,63 @@
+from som.interpreter.ast.nodes.expression_node import ExpressionNode
+from som.vm.globals import trueObject, falseObject, nilObject
+
+
+class IfInlinedNode(ExpressionNode):
+    _immutable_fields_ = [
+        "_condition_expr?",
+        "_body_expr?",
+        "universe",
+        "_expected_bool",
+        "_not_expected_bool",
+    ]
+    _child_nodes_ = ["_condition_expr", "_body_expr"]
+
+    def __init__(self, condition_expr, body_expr, if_true, source_section):
+        ExpressionNode.__init__(self, source_section)
+        self._condition_expr = self.adopt_child(condition_expr)
+        self._body_expr = self.adopt_child(body_expr)
+        self._expected_bool = trueObject if if_true else falseObject
+        self._not_expected_bool = falseObject if if_true else trueObject
+
+    def execute(self, frame):
+        result = self._condition_expr.execute(frame)
+        if self._expected_bool is result:
+            return self._body_expr.execute(frame)
+        if result is self._not_expected_bool:
+            return nilObject
+        raise NotImplementedError(
+            "Would need to generalize, but we haven't implemented that "
+            + "for the bytecode interpreter either"
+        )
+
+
+class IfElseInlinedNode(ExpressionNode):
+    _immutable_fields_ = [
+        "_condition_expr?",
+        "_true_expr?",
+        "_false_expr?",
+        "universe",
+        "_expected_bool",
+        "_not_expected_bool",
+    ]
+    _child_nodes_ = ["_condition_expr", "_true_expr", "_false_expr"]
+
+    def __init__(self, condition_expr, true_expr, false_expr, if_true, source_section):
+        ExpressionNode.__init__(self, source_section)
+        self._condition_expr = self.adopt_child(condition_expr)
+        self._true_expr = self.adopt_child(true_expr)
+        self._false_expr = self.adopt_child(false_expr)
+
+        self._expected_bool = trueObject if if_true else falseObject
+        self._not_expected_bool = falseObject if if_true else trueObject
+
+    def execute(self, frame):
+        result = self._condition_expr.execute(frame)
+        if self._expected_bool is result:
+            return self._true_expr.execute(frame)
+        if result is self._not_expected_bool:
+            return self._false_expr.execute(frame)
+        raise NotImplementedError(
+            "Would need to generalize, but we haven't implemented that "
+            + "for the bytecode interpreter either"
+        )

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -65,7 +65,13 @@ class Bytecodes(object):
     inc = return_self + 1
     dec = inc + 1
 
-    q_super_send_1 = dec + 1
+    jump = dec + 1
+    jump_on_true_top_nil = jump + 1
+    jump_on_false_top_nil = jump_on_true_top_nil + 1
+    jump_on_true_pop = jump_on_false_top_nil + 1
+    jump_on_false_pop = jump_on_true_pop + 1
+
+    q_super_send_1 = jump_on_false_pop + 1
     q_super_send_2 = q_super_send_1 + 1
     q_super_send_3 = q_super_send_2 + 1
     q_super_send_n = q_super_send_3 + 1
@@ -78,6 +84,13 @@ class Bytecodes(object):
     invalid = pop_argument + 1
 
 
+def is_one_of(bytecode, candidates):
+    for c in candidates:
+        if c == bytecode:
+            return True
+    return False
+
+
 _NUM_BYTECODES = Bytecodes.pop_argument + 1
 
 POP_X_BYTECODES = [
@@ -87,6 +100,8 @@ POP_X_BYTECODES = [
     Bytecodes.pop_field_0,
     Bytecodes.pop_field_1,
 ]
+
+PUSH_BLOCK_BYTECODES = [Bytecodes.push_block, Bytecodes.push_block_no_ctx]
 
 PUSH_CONST_BYTECODES = [
     Bytecodes.push_constant,
@@ -108,6 +123,44 @@ POP_FIELD_BYTECODES = [
     Bytecodes.pop_field,
     Bytecodes.pop_field_0,
     Bytecodes.pop_field_1,
+]
+
+JUMP_BYTECODES = [
+    Bytecodes.jump,
+    Bytecodes.jump_on_true_top_nil,
+    Bytecodes.jump_on_true_pop,
+    Bytecodes.jump_on_false_pop,
+    Bytecodes.jump_on_false_top_nil,
+]
+
+RUN_TIME_ONLY_BYTECODES = [
+    Bytecodes.push_frame,
+    Bytecodes.push_frame_0,
+    Bytecodes.push_frame_1,
+    Bytecodes.push_frame_2,
+    Bytecodes.push_inner,
+    Bytecodes.push_inner_1,
+    Bytecodes.push_inner_2,
+    Bytecodes.pop_frame,
+    Bytecodes.pop_frame_1,
+    Bytecodes.pop_frame_2,
+    Bytecodes.pop_inner,
+    Bytecodes.pop_inner_0,
+    Bytecodes.pop_inner_1,
+    Bytecodes.pop_inner_2,
+    Bytecodes.q_super_send_1,
+    Bytecodes.q_super_send_2,
+    Bytecodes.q_super_send_3,
+    Bytecodes.q_super_send_n,
+]
+
+NOT_EXPECTED_IN_BLOCK_BYTECODES = [
+    Bytecodes.halt,
+    Bytecodes.push_field_0,
+    Bytecodes.push_field_1,
+    Bytecodes.pop_field_0,
+    Bytecodes.pop_field_1,
+    Bytecodes.return_self,
 ]
 
 _BYTECODE_LENGTH = [
@@ -150,12 +203,17 @@ _BYTECODE_LENGTH = [
     2,  # send_2
     2,  # send_3
     2,  # send_n
-    2,  # super_send_1
+    2,  # super_send
     1,  # return_local
     2,  # return_non_local
     1,  # return_self
     1,  # inc
     1,  # dec
+    2,  # jump
+    2,  # jump_on_true_top_nil
+    2,  # jump_on_false_top_nil
+    2,  # jump_on_true_pop
+    2,  # jump_on_false_pop
     2,  # q_super_send_1
     2,  # q_super_send_2
     2,  # q_super_send_3
@@ -216,6 +274,11 @@ _BYTECODE_STACK_EFFECT = [
     0,  # return_self
     0,  # inc
     0,  # dec
+    0,  # jump
+    0,  # jump_on_true_top_nil
+    0,  # jump_on_false_top_nil
+    -1,  # jump_on_true_pop
+    -1,  # jump_on_false_pop
     _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # q_super_send_1
     _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # q_super_send_2
     _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # q_super_send_3

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -13,7 +13,7 @@ from som.interpreter.bc.frame import (
 )
 from som.interpreter.control_flow import ReturnException
 from som.interpreter.send import lookup_and_send_2, lookup_and_send_3
-from som.vm.globals import nilObject
+from som.vm.globals import nilObject, trueObject, falseObject
 from som.vmobjects.array import Array
 from som.vmobjects.block_bc import BcBlock
 from som.vmobjects.integer import int_0, int_1
@@ -469,6 +469,37 @@ def interpret(method, frame, max_stack_size):
             else:
                 return _not_yet_implemented()
             stack[stack_ptr] = result
+
+        elif bytecode == Bytecodes.jump:
+            next_bc_idx = current_bc_idx + method.get_bytecode(current_bc_idx + 1)
+
+        elif bytecode == Bytecodes.jump_on_true_top_nil:
+            val = stack[stack_ptr]
+            if val is trueObject:
+                next_bc_idx = current_bc_idx + method.get_bytecode(current_bc_idx + 1)
+                stack[stack_ptr] = nilObject
+            else:
+                stack_ptr -= 1
+
+        elif bytecode == Bytecodes.jump_on_false_top_nil:
+            val = stack[stack_ptr]
+            if val is falseObject:
+                next_bc_idx = current_bc_idx + method.get_bytecode(current_bc_idx + 1)
+                stack[stack_ptr] = nilObject
+            else:
+                stack_ptr -= 1
+
+        elif bytecode == Bytecodes.jump_on_true_pop:
+            val = stack[stack_ptr]
+            if val is trueObject:
+                next_bc_idx = current_bc_idx + method.get_bytecode(current_bc_idx + 1)
+            stack_ptr -= 1
+
+        elif bytecode == Bytecodes.jump_on_false_pop:
+            val = stack[stack_ptr]
+            if val is falseObject:
+                next_bc_idx = current_bc_idx + method.get_bytecode(current_bc_idx + 1)
+            stack_ptr -= 1
 
         elif bytecode == Bytecodes.q_super_send_1:
             invokable = method.get_inline_cache_invokable(current_bc_idx)

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -262,7 +262,7 @@ class BcMethod(BcAbstractMethod):
                     # these have been inlined into the outer context already
                     # so, we need to look up the right one
                     var = self._lexical_scope.get_local(idx, 0)
-                    idx = mgenc.get_inlined_local_idx(var)
+                    idx = mgenc.get_inlined_local_idx(var, 0)
                 else:
                     ctx_level -= 1
                 emit3(mgenc, bytecode, idx, ctx_level)
@@ -430,7 +430,9 @@ class BcMethod(BcAbstractMethod):
                     # at this point, the lexical scope has not been changed
                     # so, we should still be able to find the right one
                     old_var = self._lexical_scope.get_local(idx, ctx_level)
-                    new_idx = mgenc_with_inlined.get_inlined_local_idx(old_var)
+                    new_idx = mgenc_with_inlined.get_inlined_local_idx(
+                        old_var, ctx_level
+                    )
                     self.set_bytecode(i + 1, new_idx)
                 elif ctx_level > removed_ctx_level:
                     self.set_bytecode(i + 2, ctx_level - 1)

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -339,8 +339,6 @@ class BcMethod(BcAbstractMethod):
                 new_ctx_level = self.get_bytecode(i + 1) - 1
                 if new_ctx_level == 0:
                     emit_return_local(mgenc)
-                    # just padding to keep the same bytecode length
-                    emit1(mgenc, Bytecodes.halt)
                 else:
                     assert new_ctx_level == mgenc.get_max_context_level()
                     emit_return_non_local(mgenc)

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -263,6 +263,7 @@ class BcMethod(BcAbstractMethod):
             ):
                 idx = self.get_bytecode(i + 1)
                 ctx_level = self.get_bytecode(i + 2)
+                assert ctx_level > 0
                 if bytecode == Bytecodes.push_field:
                     emit_push_field_with_index(mgenc, idx, ctx_level - 1)
                 elif bytecode == Bytecodes.pop_field:
@@ -285,7 +286,7 @@ class BcMethod(BcAbstractMethod):
             elif bytecode == Bytecodes.push_block:
                 literal_idx = self.get_bytecode(i + 1)
                 block_method = self._literals[literal_idx]
-                block_method.adapt_after_inlining(1, mgenc)
+                block_method.adapt_after_outer_inlined(1, mgenc)
                 emit_push_block(mgenc, block_method, True)
 
             elif bytecode == Bytecodes.push_block_no_ctx:
@@ -386,7 +387,7 @@ class BcMethod(BcAbstractMethod):
 
         assert not jumps
 
-    def adapt_after_inlining(self, removed_ctx_level, mgenc_with_inlined):
+    def adapt_after_outer_inlined(self, removed_ctx_level, mgenc_with_inlined):
         i = 0
         while i < len(self._bytecodes):
             bytecode = self.get_bytecode(i)
@@ -435,7 +436,7 @@ class BcMethod(BcAbstractMethod):
             elif bytecode == Bytecodes.push_block:
                 literal_idx = self.get_bytecode(i + 1)
                 block_method = self._literals[literal_idx]
-                block_method.adapt_after_inlining(
+                block_method.adapt_after_outer_inlined(
                     removed_ctx_level + 1, mgenc_with_inlined
                 )
 
@@ -477,7 +478,7 @@ class BcMethod(BcAbstractMethod):
                 raise Exception(
                     "Found "
                     + bytecode_as_str(bytecode)
-                    + " bytecode, but adapt_after_inlining does not handle it yet."
+                    + " bytecode, but adapt_after_outer_inlined does not handle it yet."
                 )
 
             i += bc_length

--- a/src/som/vmobjects/method_trivial.py
+++ b/src/som/vmobjects/method_trivial.py
@@ -1,4 +1,5 @@
 from rlib.jit import elidable_promote, unroll_safe
+from som.compiler.bc.bytecode_generator import emit_push_constant, emit_push_global
 from som.interpreter.ast.frame import FRAME_AND_INNER_RCVR_IDX
 from som.interpreter.bc.frame import stack_pop_old_arguments_and_push_result
 from som.interpreter.send import lookup_and_send_2
@@ -62,6 +63,9 @@ class LiteralReturn(AbstractTrivialMethod):
             self._value,
         )
 
+    def inline(self, mgenc):
+        emit_push_constant(mgenc, self._value)
+
 
 class GlobalRead(AbstractTrivialMethod):
     _immutable_fields_ = ["_assoc?", "_global_name", "_context_level", "universe"]
@@ -104,6 +108,9 @@ class GlobalRead(AbstractTrivialMethod):
             num_args,
             value,
         )
+
+    def inline(self, mgenc):
+        emit_push_global(mgenc, self._global_name)
 
 
 class FieldRead(AbstractTrivialMethod):

--- a/tests/test_ast_inlining.py
+++ b/tests/test_ast_inlining.py
@@ -1,0 +1,482 @@
+# pylint: disable=redefined-outer-name,protected-access
+import pytest
+
+from rlib.string_stream import StringStream
+from som.compiler.ast.method_generation_context import MethodGenerationContext
+from som.compiler.ast.parser import Parser
+from som.compiler.ast.variable import Argument
+from som.compiler.class_generation_context import ClassGenerationContext
+from som.interp_type import is_bytecode_interpreter
+from som.interpreter.ast.frame import FRAME_AND_INNER_RCVR_IDX
+from som.interpreter.ast.nodes.block_node import BlockNode, BlockNodeWithContext
+from som.interpreter.ast.nodes.field_node import FieldWriteNode, FieldReadNode
+from som.interpreter.ast.nodes.global_read_node import _UninitializedGlobalReadNode
+from som.interpreter.ast.nodes.literal_node import LiteralNode
+from som.interpreter.ast.nodes.return_non_local_node import ReturnLocalNode
+from som.interpreter.ast.nodes.sequence_node import SequenceNode
+from som.interpreter.ast.nodes.specialized.literal_if import (
+    IfInlinedNode,
+    IfElseInlinedNode,
+)
+from som.interpreter.ast.nodes.variable_node import (
+    UninitializedReadNode,
+    LocalFrameVarReadNode,
+    UninitializedWriteNode,
+)
+from som.vm.current import current_universe
+from som.vm.globals import trueObject, falseObject
+
+pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
+    is_bytecode_interpreter(), reason="Tests are specific to bytecode interpreter"
+)
+
+
+def add_field(cgenc, name):
+    cgenc.add_instance_field(current_universe.symbol_for(name))
+
+
+@pytest.fixture
+def cgenc():
+    gen_c = ClassGenerationContext(current_universe)
+    gen_c.name = current_universe.symbol_for("Test")
+    return gen_c
+
+
+@pytest.fixture
+def mgenc(cgenc):
+    mgenc = MethodGenerationContext(current_universe, cgenc, None)
+    mgenc.add_argument("self", None, None)
+    return mgenc
+
+
+def parse_method(mgenc, source):
+    parser = Parser(StringStream(source.strip()), "test", current_universe)
+    return parser.method(mgenc)
+
+
+@pytest.mark.parametrize(
+    "arg_name,arg_idx",
+    [
+        ("arg1", 1),
+        ("arg2", 2),
+    ],
+)
+def test_access_arg_from_inlined_block(mgenc, arg_name, arg_idx):
+    seq = parse_method(
+        mgenc,
+        """
+        test: arg1 and: arg2 = ( true ifTrue: [ ARG ] )""".replace(
+            "ARG", arg_name
+        ),
+    )
+
+    assert isinstance(seq, SequenceNode)
+    if_node = seq._exprs[0]
+
+    assert isinstance(if_node, IfInlinedNode)
+    assert if_node._expected_bool is trueObject
+
+    if_body = if_node._body_expr
+    assert isinstance(if_body, UninitializedReadNode)
+    assert if_body._context_level == 0
+    assert if_body.var._name == arg_name
+    assert if_body.var.idx == arg_idx
+
+    assert seq._exprs[1].is_self()
+
+
+def test_access_self_from_inlined_block(mgenc):
+    seq = parse_method(
+        mgenc,
+        """
+        test: arg1 and: arg2 = ( true ifTrue: [ self ] )""",
+    )
+
+    assert isinstance(seq, SequenceNode)
+    if_node = seq._exprs[0]
+
+    assert isinstance(if_node, IfInlinedNode)
+    assert if_node._expected_bool is trueObject
+
+    if_body = if_node._body_expr
+    assert isinstance(if_body, LocalFrameVarReadNode)
+    assert if_body.is_self()
+
+    assert seq._exprs[1].is_self()
+
+
+def test_access_block_arg_from_inlined(mgenc):
+    seq = parse_method(
+        mgenc,
+        """
+        test = ( [:arg |
+            arg.
+            true ifTrue: [ arg ] ] )""",
+    )
+
+    assert isinstance(seq, SequenceNode)
+    block_node = seq._exprs[0]
+
+    assert isinstance(block_node, BlockNode)
+    method = block_node._value
+    seq = method.invokable.expr_or_sequence
+
+    arg_read = seq._exprs[0]
+    assert arg_read._context_level == 0
+    assert arg_read.var._name == "arg"
+    assert arg_read.var.idx == 1
+
+    assert isinstance(seq._exprs[1], IfInlinedNode)
+
+    body = seq._exprs[1]._body_expr
+    assert isinstance(body, UninitializedReadNode)
+    assert body._context_level == 0
+    assert body.var._name == "arg"
+    assert body.var.idx == 1
+
+    assert body.var is arg_read.var
+
+
+@pytest.mark.parametrize(
+    "literal,lit_type",
+    [
+        ("0", LiteralNode),
+        ("1", LiteralNode),
+        ("-10", LiteralNode),
+        ("3333", LiteralNode),
+        ("'str'", LiteralNode),
+        ("#sym", LiteralNode),
+        ("1.1", LiteralNode),
+        ("-2342.234", LiteralNode),
+        ("true", LiteralNode),
+        ("false", LiteralNode),
+        ("nil", LiteralNode),
+        ("SomeGlobal", _UninitializedGlobalReadNode),
+        ("[]", BlockNode),
+        ("[ self ]", BlockNodeWithContext),
+    ],
+)
+def test_if_true_with_literal_return(mgenc, literal, lit_type):
+    source = """
+        test = (
+            self method ifTrue: [ LITERAL ].
+        )""".replace(
+        "LITERAL", literal
+    )
+    ast = parse_method(mgenc, source)
+
+    assert isinstance(ast._exprs[0], IfInlinedNode)
+
+    body = ast._exprs[0]._body_expr
+    assert isinstance(body, lit_type)
+
+
+@pytest.mark.parametrize(
+    "if_selector,expected_bool,unexpected_bool",
+    [
+        ("ifTrue:", trueObject, falseObject),
+        ("ifFalse:", falseObject, trueObject),
+    ],
+)
+def test_if_arg(mgenc, if_selector, expected_bool, unexpected_bool):
+    ast = parse_method(
+        mgenc,
+        """
+        test: arg = (
+            #start.
+            self method IF_SELECTOR [ arg ].
+            #end
+        )""".replace(
+            "IF_SELECTOR", if_selector
+        ),
+    )
+
+    assert isinstance(ast._exprs[1], IfInlinedNode)
+
+    if_node = ast._exprs[1]
+    assert if_node._expected_bool is expected_bool
+    assert if_node._not_expected_bool is unexpected_bool
+
+
+def test_if_true_and_inc_field(cgenc, mgenc):
+    add_field(cgenc, "field")
+    ast = parse_method(
+        mgenc,
+        """
+        test: arg = (
+            #start.
+            (self key: 5) ifTrue: [ field := field + 1 ].
+            #end
+        )""",
+    )
+
+    assert isinstance(ast._exprs[1], IfInlinedNode)
+    field_write = ast._exprs[1]._body_expr
+
+    assert isinstance(field_write, FieldWriteNode)
+
+    assert field_write._field_idx == 0
+    assert isinstance(field_write._self_exp, LocalFrameVarReadNode)
+    assert field_write._self_exp._frame_idx == FRAME_AND_INNER_RCVR_IDX
+
+    self_of_read = field_write._value_exp._rcvr_expr._self_exp
+    assert isinstance(self_of_read, LocalFrameVarReadNode)
+    assert self_of_read._frame_idx == FRAME_AND_INNER_RCVR_IDX
+
+
+def test_if_true_and_inc_arg(mgenc):
+    ast = parse_method(
+        mgenc,
+        """
+        test: arg = (
+            #start.
+            (self key: 5) ifTrue: [ arg + 1 ].
+            #end
+        )""",
+    )
+
+    assert isinstance(ast._exprs[1], IfInlinedNode)
+    plus_message = ast._exprs[1]._body_expr
+
+    arg_node = plus_message._rcvr_expr
+    assert arg_node._context_level == 0
+    assert arg_node.var._name == "arg"
+    assert arg_node.var.idx == 1
+
+
+def test_nested_ifs(cgenc, mgenc):
+    add_field(cgenc, "field")
+    ast = parse_method(
+        mgenc,
+        """
+        test: arg = (
+            true ifTrue: [
+                false ifFalse: [
+                  ^ field - arg
+                ]
+            ]
+        )""",
+    )
+
+    assert isinstance(ast._exprs[0], IfInlinedNode)
+    if_node = ast._exprs[0]
+    assert isinstance(if_node._body_expr, IfInlinedNode)
+    assert isinstance(if_node._body_expr._body_expr, ReturnLocalNode)
+
+    msg = if_node._body_expr._body_expr._expr
+    rcvr = msg._rcvr_expr
+    assert isinstance(rcvr, FieldReadNode)
+    assert isinstance(rcvr._self_exp, LocalFrameVarReadNode)
+    assert rcvr._self_exp.is_self()
+
+    arg = msg._arg_exprs[0]
+    assert arg._context_level == 0
+    assert isinstance(arg.var, Argument)
+    assert arg.var._name == "arg"
+    assert arg.var.idx == 1
+
+
+def test_nested_ifs_and_locals(cgenc, mgenc):
+    add_field(cgenc, "field")
+    seq = parse_method(
+        mgenc,
+        """
+        test: arg = (
+          | a b c d |
+          a := b.
+          true ifTrue: [
+            | e f g |
+            e := 2.
+            c := 3.
+            false ifFalse: [
+              | h i j |
+              h := 1.
+              ^ i - j - f - g - d ] ] )""",
+    )
+
+    if_true = seq._exprs[1]
+    assert isinstance(if_true, IfInlinedNode)
+
+    if_false = if_true._body_expr._exprs[2]
+    assert isinstance(if_false, IfInlinedNode)
+
+    body_if_false = if_false._body_expr._exprs
+
+    write = body_if_false[0]
+    assert isinstance(write, UninitializedWriteNode)
+    assert write._context_level == 0
+    assert write._var._name == "h"
+
+    return_local = body_if_false[1]
+    assert isinstance(return_local, ReturnLocalNode)
+
+
+def test_nested_ifs_and_non_inlined_blocks(cgenc, mgenc):
+    add_field(cgenc, "field")
+    seq = parse_method(
+        mgenc,
+        """
+        test: arg = (
+          | a |
+          a := 1.
+          true ifTrue: [
+            | e |
+            e := 0.
+            [ a := 1. a ].
+            false ifFalse: [
+              | h |
+              h := 1.
+              [ h + a + e ].
+              ^ h ] ].
+
+          [ a ]
+        )""",
+    )
+
+    if_true = seq._exprs[1]
+    assert isinstance(if_true, IfInlinedNode)
+
+    block_node = if_true._body_expr._exprs[1]
+    method_expr = block_node._value.invokable.expr_or_sequence._exprs
+    write = method_expr[0]
+    assert write._context_level == 1
+    assert write._var._name == "a"
+    assert write._var.idx == 0
+
+    if_false = if_true._body_expr._exprs[2]
+    assert isinstance(if_false, IfInlinedNode)
+
+    body_if_false = if_false._body_expr._exprs
+
+    write = body_if_false[0]
+    assert isinstance(write, UninitializedWriteNode)
+    assert write._context_level == 0
+    assert write._var._name == "h"
+
+    return_local = body_if_false[2]
+    assert isinstance(return_local, ReturnLocalNode)
+
+
+def test_nested_non_inlined_blocks(cgenc, mgenc):
+    add_field(cgenc, "field")
+    ast = parse_method(
+        mgenc,
+        """
+        test: a = ( | b |
+          true ifFalse: [ | c |
+            a. b. c.
+            [:d |
+              a. b. c. d.
+              [:e |
+                a. b. c. d. e ] ] ]
+        )""",
+    )
+
+    if_false = ast._exprs[0]
+    assert isinstance(if_false, IfInlinedNode)
+
+    block_seq = if_false._body_expr._exprs[3]._value.invokable.expr_or_sequence
+    read_a = block_seq._exprs[0]
+    assert read_a._context_level == 1
+    assert read_a.var._name == "a"
+    assert read_a.var.idx == 1
+
+    read_b = block_seq._exprs[1]
+    assert read_b._context_level == 1
+    assert read_b.var._name == "b"
+    assert read_b.var.idx == 0
+
+    block_seq = block_seq._exprs[4]._value.invokable.expr_or_sequence
+    read_a = block_seq._exprs[0]
+    assert read_a._context_level == 2
+    assert read_a.var._name == "a"
+    assert read_a.var.idx == 1
+
+    read_b = block_seq._exprs[1]
+    assert read_b._context_level == 2
+    assert read_b.var._name == "b"
+    assert read_b.var.idx == 0
+
+
+@pytest.mark.parametrize(
+    "sel1,sel2,expected_bool,unexpected_bool",
+    [
+        ("ifTrue:", "ifFalse:", trueObject, falseObject),
+        ("ifFalse:", "ifTrue:", falseObject, trueObject),
+    ],
+)
+def test_if_true_if_false_return(mgenc, sel1, sel2, expected_bool, unexpected_bool):
+    seq = parse_method(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            ^ self method SEL1 [ ^ arg1 ] SEL2 [ arg2 ]
+        )""".replace(
+            "SEL1", sel1
+        ).replace(
+            "SEL2", sel2
+        ),
+    )
+
+    assert isinstance(seq._exprs[1], IfElseInlinedNode)
+    if_node = seq._exprs[1]
+    assert if_node._expected_bool is expected_bool
+    assert if_node._not_expected_bool is unexpected_bool
+
+
+def test_block_block_inlined_self(cgenc, mgenc):
+    add_field(cgenc, "field")
+    ast = parse_method(
+        mgenc,
+        """
+        test = (
+          [:a |
+            [:b |
+              b ifTrue: [ field := field + 1 ] ] ]
+        )""",
+    )
+    block_a = ast._exprs[0]._value.invokable.expr_or_sequence
+    block_b_if_true = block_a._value.invokable.expr_or_sequence
+
+    read_node = block_b_if_true._condition_expr
+    assert read_node._context_level == 0
+    assert read_node.var._name == "b"
+    assert read_node.var.idx == 1
+
+    write_node = block_b_if_true._body_expr
+    assert write_node._field_idx == 0
+
+    assert write_node._self_exp._frame_idx == FRAME_AND_INNER_RCVR_IDX
+    assert write_node._self_exp._context_level == 2
+
+
+def test_to_do_block_block_inlined_self(cgenc, mgenc):
+    add_field(cgenc, "field")
+    ast = parse_method(
+        mgenc,
+        """
+        test = (
+          | l1 l2 |
+          1 to: 2 do: [:a |
+            l1 do: [:b |
+              b ifTrue: [ l2 := l2 + 1 ] ] ]
+        )""",
+    )
+    block_a = ast._exprs[0]._arg_exprs[1]._value.invokable.expr_or_sequence
+    block_b_if_true = block_a._arg_exprs[0]._value.invokable.expr_or_sequence
+
+    read_node = block_b_if_true._condition_expr
+    assert read_node._context_level == 0
+    assert read_node.var._name == "b"
+    assert read_node.var.idx == 1
+
+    write_node = block_b_if_true._body_expr
+    assert write_node._context_level == 2
+    assert write_node._var._name == "l2"
+    assert write_node._var.idx == 1
+
+    read_l2_node = write_node._value_expr._rcvr_expr
+    assert read_l2_node._context_level == 2
+    assert read_l2_node.var._name == "l2"
+    assert read_l2_node.var.idx == 1

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -299,20 +299,16 @@ def test_if_true_and_inc_field(cgenc, mgenc):
         )""",
     )
 
-    assert len(bytecodes) == 22
+    assert len(bytecodes) == 18
     assert Bytecodes.send_2 == bytecodes[6]
     assert Bytecodes.jump_on_false_top_nil == bytecodes[8]
-    assert bytecodes[9] == 10, "jump offset"
+    assert bytecodes[9] == 6, "jump offset"
 
-    assert Bytecodes.push_field == bytecodes[10]
-    assert bytecodes[11] == 0, "field idx"
-    assert bytecodes[12] == 0, "ctx level"
-    assert Bytecodes.inc == bytecodes[13]
-    assert Bytecodes.dup == bytecodes[14]
-    assert Bytecodes.pop_field == bytecodes[15]
-    assert bytecodes[16] == 0, "field idx"
-    assert bytecodes[17] == 0, "ctx level"
-    assert Bytecodes.pop == bytecodes[18]
+    assert Bytecodes.push_field_0 == bytecodes[10]
+    assert Bytecodes.inc == bytecodes[11]
+    assert Bytecodes.dup == bytecodes[12]
+    assert Bytecodes.pop_field_0 == bytecodes[13]
+    assert Bytecodes.pop == bytecodes[14]
 
 
 def test_if_true_and_inc_arg(mgenc):
@@ -385,20 +381,18 @@ def test_nested_ifs(cgenc, mgenc):
         )""",
     )
 
-    assert len(bytecodes) == 18
+    assert len(bytecodes) == 16
     assert Bytecodes.push_global == bytecodes[0]
     assert Bytecodes.jump_on_false_top_nil == bytecodes[2]
-    assert bytecodes[3] == 15
+    assert bytecodes[3] == 13
     assert Bytecodes.jump_on_true_top_nil == bytecodes[6]
-    assert Bytecodes.push_field == bytecodes[8]
-    assert bytecodes[9] == 0, "field idx"
-    assert bytecodes[10] == 0, "ctx_level"
-    assert Bytecodes.push_argument == bytecodes[11]
-    assert bytecodes[12] == 1, "arg idx"
-    assert bytecodes[13] == 0, "ctx_level"
-    assert Bytecodes.send_2 == bytecodes[14]
-    assert Bytecodes.return_local == bytecodes[16]
-    assert Bytecodes.return_self == bytecodes[17]
+    assert Bytecodes.push_field_0 == bytecodes[8]
+    assert Bytecodes.push_argument == bytecodes[9]
+    assert bytecodes[10] == 1, "arg idx"
+    assert bytecodes[11] == 0, "ctx_level"
+    assert Bytecodes.send_2 == bytecodes[12]
+    assert Bytecodes.return_local == bytecodes[14]
+    assert Bytecodes.return_self == bytecodes[15]
 
 
 def test_nested_ifs_and_locals(cgenc, mgenc):
@@ -818,7 +812,10 @@ def test_if_inline_and_constant_bc_length(mgenc):
     dump(mgenc)
 
     assert Bytecodes.jump_on_true_top_nil == bytecodes[12]
-    assert bytecodes[13] == 10, "jump offset, should point to correct bytecode" + " and not be affected by changing length of bytecodes in the block"
+    assert bytecodes[13] == 10, (
+        "jump offset, should point to correct bytecode"
+        + " and not be affected by changing length of bytecodes in the block"
+    )
 
 
 def test_block_dup_pop_argument_pop_return_arg(bgenc):

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -7,7 +7,7 @@ from som.compiler.bc.method_generation_context import MethodGenerationContext
 from som.compiler.bc.parser import Parser
 from som.compiler.class_generation_context import ClassGenerationContext
 from som.interp_type import is_ast_interpreter
-from som.interpreter.bc.bytecodes import Bytecodes
+from som.interpreter.bc.bytecodes import Bytecodes, bytecode_length
 from som.vm.current import current_universe
 
 pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
@@ -187,6 +187,588 @@ def test_send_dup_pop_field_return_local_period(cgenc, mgenc):
     assert Bytecodes.return_local == bytecodes[7]
 
 
+@pytest.mark.parametrize(
+    "literal,bytecode",
+    [
+        ("0", Bytecodes.push_0),
+        ("1", Bytecodes.push_1),
+        ("-10", Bytecodes.push_constant_2),
+        ("3333", Bytecodes.push_constant_2),
+        ("'str'", Bytecodes.push_constant_2),
+        ("#sym", Bytecodes.push_constant_2),
+        ("1.1", Bytecodes.push_constant_2),
+        ("-2342.234", Bytecodes.push_constant_2),
+        ("true", Bytecodes.push_constant_2),
+        ("false", Bytecodes.push_constant_2),
+        ("nil", Bytecodes.push_nil),
+        ("SomeGlobal", Bytecodes.push_global),
+        ("[]", Bytecodes.push_block_no_ctx),
+        ("[ self ]", Bytecodes.push_block),
+    ],
+)
+def test_if_true_with_literal_return(mgenc, literal, bytecode):
+    source = """
+        test = (
+            self method ifTrue: [ LITERAL ].
+        )""".replace(
+        "LITERAL", literal
+    )
+    bytecodes = method_to_bytecodes(mgenc, source)
+
+    length = bytecode_length(bytecode)
+
+    assert len(bytecodes) == 9 + length
+    assert Bytecodes.push_argument == bytecodes[0]
+    assert Bytecodes.send_1 == bytecodes[3]
+    assert Bytecodes.jump_on_false_top_nil == bytecodes[5]
+
+    assert bytecode == bytecodes[7]
+
+    assert Bytecodes.pop == bytecodes[7 + length]
+    assert Bytecodes.return_self == bytecodes[7 + length + 1]
+
+
+@pytest.mark.parametrize(
+    "if_selector,jump_bytecode",
+    [
+        ("ifTrue:", Bytecodes.jump_on_false_top_nil),
+        ("ifFalse:", Bytecodes.jump_on_true_top_nil),
+    ],
+)
+def test_if_arg(mgenc, if_selector, jump_bytecode):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg = (
+            #start.
+            self method IF_SELECTOR [ arg ].
+            #end
+        )""".replace(
+            "IF_SELECTOR", if_selector
+        ),
+    )
+
+    assert len(bytecodes) == 16
+    assert Bytecodes.push_constant_0 == bytecodes[0]
+    assert Bytecodes.pop == bytecodes[1]
+    assert Bytecodes.push_argument == bytecodes[2]
+    assert Bytecodes.send_1 == bytecodes[5]
+    assert jump_bytecode == bytecodes[7]
+    assert bytecodes[8] == 5, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[9]
+    assert bytecodes[10] == 1, "arg idx"
+    assert bytecodes[11] == 0, "ctx level"
+    assert Bytecodes.pop == bytecodes[12]
+    assert Bytecodes.push_constant == bytecodes[13]
+    assert Bytecodes.return_self == bytecodes[15]
+
+
+def test_keyword_if_true_arg(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg = (
+            #start.
+            (self key: 5) ifTrue: [ arg ].
+            #end
+        )""",
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 17
+    assert Bytecodes.send_2 == bytecodes[6]
+    assert Bytecodes.jump_on_false_top_nil == bytecodes[8]
+    assert bytecodes[9] == 5, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[10]
+    assert bytecodes[11] == 1, "arg idx"
+    assert bytecodes[12] == 0, "ctx level"
+    assert Bytecodes.pop == bytecodes[13]
+    assert Bytecodes.push_constant == bytecodes[14]
+
+
+def test_if_true_and_inc_field(cgenc, mgenc):
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg = (
+            #start.
+            (self key: 5) ifTrue: [ field := field + 1 ].
+            #end
+        )""",
+    )
+
+    assert len(bytecodes) == 22
+    assert Bytecodes.send_2 == bytecodes[6]
+    assert Bytecodes.jump_on_false_top_nil == bytecodes[8]
+    assert bytecodes[9] == 10, "jump offset"
+
+    assert Bytecodes.push_field == bytecodes[10]
+    assert bytecodes[11] == 0, "field idx"
+    assert bytecodes[12] == 0, "ctx level"
+    assert Bytecodes.inc == bytecodes[13]
+    assert Bytecodes.dup == bytecodes[14]
+    assert Bytecodes.pop_field == bytecodes[15]
+    assert bytecodes[16] == 0, "field idx"
+    assert bytecodes[17] == 0, "ctx level"
+    assert Bytecodes.pop == bytecodes[18]
+
+
+def test_if_true_and_inc_arg(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg = (
+            #start.
+            (self key: 5) ifTrue: [ arg + 1 ].
+            #end
+        )""",
+    )
+
+    assert len(bytecodes) == 18
+    assert Bytecodes.send_2 == bytecodes[6]
+    assert Bytecodes.jump_on_false_top_nil == bytecodes[8]
+    assert bytecodes[9] == 6, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[10]
+    assert bytecodes[11] == 1, "arg idx"
+    assert bytecodes[12] == 0, "ctx level"
+    assert Bytecodes.inc == bytecodes[13]
+    assert Bytecodes.pop == bytecodes[14]
+    assert Bytecodes.push_constant == bytecodes[15]
+
+
+@pytest.mark.parametrize(
+    "if_selector,jump_bytecode",
+    [
+        ("ifTrue:", Bytecodes.jump_on_false_top_nil),
+        ("ifFalse:", Bytecodes.jump_on_true_top_nil),
+    ],
+)
+def test_if_return_non_local(mgenc, if_selector, jump_bytecode):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg = (
+            #start.
+            self method IF_SELECTOR [ ^ arg ].
+            #end
+        )""".replace(
+            "IF_SELECTOR", if_selector
+        ),
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 18
+    assert Bytecodes.send_1 == bytecodes[5]
+    assert jump_bytecode == bytecodes[7]
+    assert bytecodes[8] == 7, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[9]
+    assert bytecodes[10] == 1, "arg idx"
+    assert bytecodes[11] == 0, "ctx level"
+    assert Bytecodes.return_local == bytecodes[12]
+    assert (
+        Bytecodes.halt == bytecodes[13]
+    ), "because the original return_non_local has length=2"
+    assert Bytecodes.pop == bytecodes[14]
+
+
+def test_nested_ifs(cgenc, mgenc):
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg = (
+            true ifTrue: [
+                false ifFalse: [
+                  ^ field - arg
+                ]
+            ]
+        )""",
+    )
+
+    assert len(bytecodes) == 19
+    assert Bytecodes.push_global == bytecodes[0]
+    assert Bytecodes.jump_on_false_top_nil == bytecodes[2]
+    assert bytecodes[3] == 16
+    assert Bytecodes.jump_on_true_top_nil == bytecodes[6]
+    assert Bytecodes.push_field == bytecodes[8]
+    assert bytecodes[9] == 0, "field idx"
+    assert bytecodes[10] == 0, "ctx_level"
+    assert Bytecodes.push_argument == bytecodes[11]
+    assert bytecodes[12] == 1, "arg idx"
+    assert bytecodes[13] == 0, "ctx_level"
+    assert Bytecodes.send_2 == bytecodes[14]
+    assert Bytecodes.return_local == bytecodes[16]
+    assert Bytecodes.halt == bytecodes[17]
+    assert Bytecodes.return_self == bytecodes[18]
+
+
+def test_nested_ifs_and_locals(cgenc, mgenc):
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg = (
+          | a b c d |
+          a := b.
+          true ifTrue: [
+            | e f g |
+            e := 2.
+            c := 3.
+            false ifFalse: [
+              | h i j |
+              h := 1.
+              ^ i - j - f - g - d ] ] )""",
+    )
+
+    assert len(bytecodes) == 54
+    assert Bytecodes.push_local == bytecodes[0]
+    assert bytecodes[1] == 1
+    assert bytecodes[2] == 0
+
+    assert Bytecodes.pop_local == bytecodes[3]
+    assert bytecodes[4] == 0
+    assert bytecodes[5] == 0
+
+    assert Bytecodes.jump_on_false_top_nil == bytecodes[8]
+    assert bytecodes[9] == 45, "jump offset"
+
+    assert Bytecodes.pop_local == bytecodes[12]
+    assert bytecodes[13] == 4
+    assert bytecodes[14] == 0
+
+    assert Bytecodes.pop_local == bytecodes[17]
+    assert bytecodes[18] == 2
+    assert bytecodes[19] == 0
+
+    assert Bytecodes.jump_on_true_top_nil == bytecodes[22]
+    assert bytecodes[23] == 31, "jump offset"
+
+    assert Bytecodes.pop_local == bytecodes[25]
+    assert bytecodes[26] == 7
+    assert bytecodes[27] == 0
+
+    assert Bytecodes.push_local == bytecodes[46]
+    assert bytecodes[47] == 3
+    assert bytecodes[48] == 0
+
+
+def test_nested_ifs_and_non_inlined_blocks(cgenc, mgenc):
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg = (
+          | a |
+          a := 1.
+          true ifTrue: [
+            | e |
+            e := 0.
+            [ a := 1. a ].
+            false ifFalse: [
+              | h |
+              h := 1.
+              [ h + a + e ].
+              ^ h ] ].
+
+          [ a ]
+        )""",
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 35
+    assert Bytecodes.push_global == bytecodes[4]
+    assert Bytecodes.jump_on_false_top_nil == bytecodes[6]
+    assert bytecodes[7] == 25, "jump offset"
+    assert Bytecodes.pop_local == bytecodes[9]
+    assert bytecodes[10] == 1, "e var idx"
+    assert bytecodes[11] == 0, "e ctx idx"
+
+    block_method = mgenc.get_constant(12)
+    assert block_method.get_bytecode(1) == Bytecodes.pop_local
+    assert block_method.get_bytecode(2) == 0, "a var idx"
+    assert block_method.get_bytecode(3) == 1, "a ctx level"
+
+    assert Bytecodes.jump_on_true_top_nil == bytecodes[17]
+    assert bytecodes[18] == 14, "jump offset"
+
+    assert Bytecodes.pop_local == bytecodes[20]
+    assert bytecodes[21] == 2, "h var idx"
+    assert bytecodes[22] == 0, "h ctx idx"
+
+    block_method = mgenc.get_constant(23)
+    assert block_method.get_bytecode(0) == Bytecodes.push_local
+    assert block_method.get_bytecode(1) == 2, "h var idx"
+    assert block_method.get_bytecode(2) == 1, "h ctx level"
+
+    assert block_method.get_bytecode(3) == Bytecodes.push_local
+    assert block_method.get_bytecode(4) == 0, "a var idx"
+    assert block_method.get_bytecode(5) == 1, "a ctx level"
+
+    assert block_method.get_bytecode(8) == Bytecodes.push_local
+    assert block_method.get_bytecode(9) == 1, "e var idx"
+    assert block_method.get_bytecode(10) == 1, "e ctx level"
+
+    block_method = mgenc.get_constant(32)
+    assert block_method.get_bytecode(0) == Bytecodes.push_local
+    assert block_method.get_bytecode(1) == 0, "a var idx"
+    assert block_method.get_bytecode(2) == 1, "a ctx level"
+
+
+def test_nested_non_inlined_blocks(cgenc, mgenc):
+    add_field(cgenc, "field")
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: a = ( | b |
+          true ifFalse: [ | c |
+            a. b. c.
+            [:d |
+              a. b. c. d.
+              [:e |
+                a. b. c. d. e ] ] ]
+        )""",
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 19
+    assert Bytecodes.jump_on_true_top_nil == bytecodes[2]
+    assert bytecodes[3] == 16, "jump offset"
+    assert Bytecodes.push_argument == bytecodes[4]
+    assert bytecodes[5] == 1, "a var idx"
+    assert bytecodes[6] == 0, "a ctx idx"
+
+    assert Bytecodes.push_local == bytecodes[8]
+    assert bytecodes[9] == 0, "b var idx"
+    assert bytecodes[10] == 0, "b ctx idx"
+
+    assert Bytecodes.push_local == bytecodes[12]
+    assert bytecodes[13] == 1, "c var idx"
+    assert bytecodes[14] == 0, "c ctx idx"
+
+    block_method = mgenc.get_constant(16)
+    assert block_method.get_bytecode(0) == Bytecodes.push_argument
+    assert block_method.get_bytecode(1) == 1, "a var idx"
+    assert block_method.get_bytecode(2) == 1, "a ctx level"
+
+    assert block_method.get_bytecode(4) == Bytecodes.push_local
+    assert block_method.get_bytecode(5) == 0, "b var idx"
+    assert block_method.get_bytecode(6) == 1, "b ctx level"
+
+    assert block_method.get_bytecode(8) == Bytecodes.push_local
+    assert block_method.get_bytecode(9) == 1, "c var idx"
+    assert block_method.get_bytecode(10) == 1, "c ctx level"
+
+    assert block_method.get_bytecode(12) == Bytecodes.push_argument
+    assert block_method.get_bytecode(13) == 1, "d var idx"
+    assert block_method.get_bytecode(14) == 0, "d ctx level"
+
+    block_method = block_method.get_constant(16)
+    assert block_method.get_bytecode(0) == Bytecodes.push_argument
+    assert block_method.get_bytecode(1) == 1, "a var idx"
+    assert block_method.get_bytecode(2) == 2, "a ctx level"
+
+    assert block_method.get_bytecode(4) == Bytecodes.push_local
+    assert block_method.get_bytecode(5) == 0, "b var idx"
+    assert block_method.get_bytecode(6) == 2, "b ctx level"
+
+    assert block_method.get_bytecode(8) == Bytecodes.push_local
+    assert block_method.get_bytecode(9) == 1, "c var idx"
+    assert block_method.get_bytecode(10) == 2, "c ctx level"
+
+    assert block_method.get_bytecode(12) == Bytecodes.push_argument
+    assert block_method.get_bytecode(13) == 1, "d var idx"
+    assert block_method.get_bytecode(14) == 1, "d ctx level"
+
+    assert block_method.get_bytecode(16) == Bytecodes.push_argument
+    assert block_method.get_bytecode(17) == 1, "e var idx"
+    assert block_method.get_bytecode(18) == 0, "e ctx level"
+
+
+def test_block_if_true_arg(bgenc):
+    bytecodes = block_to_bytecodes(
+        bgenc,
+        """
+        [:arg | #start.
+            self method ifTrue: [ arg ].
+            #end
+        ]""",
+    )
+
+    dump(bgenc)
+    assert len(bytecodes) == 16
+    assert Bytecodes.send_1 == bytecodes[5]
+    assert Bytecodes.jump_on_false_top_nil == bytecodes[7]
+    assert bytecodes[8] == 5, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[9]
+    assert bytecodes[10] == 1, "arg idx"
+    assert bytecodes[11] == 0, "ctx level"
+    assert Bytecodes.pop == bytecodes[12]
+    assert Bytecodes.push_constant == bytecodes[13]
+
+
+def test_block_if_true_method_arg(mgenc, bgenc):
+    mgenc.add_argument("arg", None, None)
+    bytecodes = block_to_bytecodes(
+        bgenc,
+        """
+        [ #start.
+            self method ifTrue: [ arg ].
+            #end
+        ]""",
+    )
+
+    dump(bgenc)
+    assert len(bytecodes) == 16
+    assert Bytecodes.jump_on_false_top_nil == bytecodes[7]
+    assert bytecodes[8] == 5, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[9]
+    assert bytecodes[10] == 1, "arg idx"
+    assert bytecodes[11] == 1, "ctx level"
+    assert Bytecodes.pop == bytecodes[12]
+    assert Bytecodes.push_constant == bytecodes[13]
+
+
+def test_if_true_if_false_arg(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            self method ifTrue: [ arg1 ] ifFalse: [ arg2 ].
+            #end
+        )""",
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 1
+
+
+def test_if_true_if_false_nlr_arg1(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ].
+            #end
+        )""",
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 1
+
+
+def test_if_true_if_false_nlr_arg2(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            self method ifTrue: [ arg1 ] ifFalse: [ ^ arg2 ].
+            #end
+        )""",
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 1
+
+
+def test_if_true_if_false_return(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            ^ self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ]
+        )""",
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 1
+
+
+def test_if_false_if_true_return(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            ^ self method ifFalse: [ ^ arg1 ] ifTrue: [ arg2 ]
+        )""",
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 1
+
+
+def test_if_push_constant_same(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test = (
+          #a. #b. #c. #d.
+          true ifFalse: [ #a. #b. #c. #d. ]
+        )""",
+    )
+
+    assert len(bytecodes) == 22
+    assert Bytecodes.push_constant_0 == bytecodes[0]
+    assert Bytecodes.push_constant_1 == bytecodes[2]
+    assert Bytecodes.push_constant_2 == bytecodes[4]
+    assert Bytecodes.push_constant == bytecodes[6]
+    assert bytecodes[7] == 3, "const idx"
+
+    assert Bytecodes.jump_on_true_top_nil == bytecodes[11]
+    assert bytecodes[12] == 10, "jump offset"
+
+    assert Bytecodes.push_constant_0 == bytecodes[13]
+    assert Bytecodes.push_constant_1 == bytecodes[15]
+    assert Bytecodes.push_constant_2 == bytecodes[17]
+    assert Bytecodes.push_constant == bytecodes[19]
+    assert bytecodes[20] == 3, "const idx"
+
+
+def test_if_push_constant_different(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test = (
+          #a. #b. #c. #d.
+          true ifFalse: [ #e. #f. #g. #h. ]
+        )""",
+    )
+
+    dump(mgenc)
+    assert len(bytecodes) == 25
+    assert Bytecodes.push_constant_0 == bytecodes[0]
+    assert Bytecodes.push_constant_1 == bytecodes[2]
+    assert Bytecodes.push_constant_2 == bytecodes[4]
+    assert Bytecodes.push_constant == bytecodes[6]
+    assert bytecodes[7] == 3, "const idx"
+
+    assert Bytecodes.jump_on_true_top_nil == bytecodes[11]
+    assert bytecodes[12] == 13, "jump offset"
+
+    assert Bytecodes.push_constant == bytecodes[13]
+    assert bytecodes[14] == 6, "const idx"
+
+    assert Bytecodes.push_constant == bytecodes[16]
+    assert bytecodes[17] == 7, "const idx"
+
+    assert Bytecodes.push_constant == bytecodes[19]
+    assert bytecodes[20] == 8, "const idx"
+
+    assert Bytecodes.push_constant == bytecodes[22]
+    assert bytecodes[23] == 9, "const idx"
+
+
 def test_block_dup_pop_argument_pop_return_arg(bgenc):
     bytecodes = block_to_bytecodes(bgenc, "[:arg | arg := 1. arg ]")
 
@@ -247,3 +829,36 @@ def test_block_dup_pop_field_return_local_dot(cgenc, bgenc):
     assert Bytecodes.dup == bytecodes[1]
     assert Bytecodes.pop_field == bytecodes[2]
     assert Bytecodes.return_local == bytecodes[5]
+
+
+@pytest.mark.parametrize(
+    "if_selector,jump_bytecode",
+    [
+        ("ifTrue:", Bytecodes.jump_on_false_top_nil),
+        ("ifFalse:", Bytecodes.jump_on_true_top_nil),
+    ],
+)
+def test_block_if_return_non_local(bgenc, if_selector, jump_bytecode):
+    bytecodes = block_to_bytecodes(
+        bgenc,
+        """
+        [:arg |
+            #start.
+            self method IF_SELECTOR [ ^ arg ].
+            #end
+        ]""".replace(
+            "IF_SELECTOR", if_selector
+        ),
+    )
+
+    assert len(bytecodes) == 18
+    assert Bytecodes.send_1 == bytecodes[5]
+    assert jump_bytecode == bytecodes[7]
+    assert bytecodes[8] == 7, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[9]
+    assert bytecodes[10] == 1, "arg idx"
+    assert bytecodes[11] == 0, "ctx level"
+    assert Bytecodes.return_non_local == bytecodes[12]
+    assert bytecodes[13] == 1
+    assert Bytecodes.pop == bytecodes[14]

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -629,77 +629,77 @@ def test_block_if_true_method_arg(mgenc, bgenc):
     assert Bytecodes.push_constant == bytecodes[13]
 
 
-def test_if_true_if_false_arg(mgenc):
-    bytecodes = method_to_bytecodes(
-        mgenc,
-        """
-        test: arg1 with: arg2 = (
-            #start.
-            self method ifTrue: [ arg1 ] ifFalse: [ arg2 ].
-            #end
-        )""",
-    )
-
-    dump(mgenc)
-    assert len(bytecodes) == 1
-
-
-def test_if_true_if_false_nlr_arg1(mgenc):
-    bytecodes = method_to_bytecodes(
-        mgenc,
-        """
-        test: arg1 with: arg2 = (
-            #start.
-            self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ].
-            #end
-        )""",
-    )
-
-    dump(mgenc)
-    assert len(bytecodes) == 1
-
-
-def test_if_true_if_false_nlr_arg2(mgenc):
-    bytecodes = method_to_bytecodes(
-        mgenc,
-        """
-        test: arg1 with: arg2 = (
-            #start.
-            self method ifTrue: [ arg1 ] ifFalse: [ ^ arg2 ].
-            #end
-        )""",
-    )
-
-    dump(mgenc)
-    assert len(bytecodes) == 1
-
-
-def test_if_true_if_false_return(mgenc):
-    bytecodes = method_to_bytecodes(
-        mgenc,
-        """
-        test: arg1 with: arg2 = (
-            #start.
-            ^ self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ]
-        )""",
-    )
-
-    dump(mgenc)
-    assert len(bytecodes) == 1
-
-
-def test_if_false_if_true_return(mgenc):
-    bytecodes = method_to_bytecodes(
-        mgenc,
-        """
-        test: arg1 with: arg2 = (
-            #start.
-            ^ self method ifFalse: [ ^ arg1 ] ifTrue: [ arg2 ]
-        )""",
-    )
-
-    dump(mgenc)
-    assert len(bytecodes) == 1
+# def test_if_true_if_false_arg(mgenc):
+#     bytecodes = method_to_bytecodes(
+#         mgenc,
+#         """
+#         test: arg1 with: arg2 = (
+#             #start.
+#             self method ifTrue: [ arg1 ] ifFalse: [ arg2 ].
+#             #end
+#         )""",
+#     )
+#
+#     dump(mgenc)
+#     assert len(bytecodes) == 1
+#
+#
+# def test_if_true_if_false_nlr_arg1(mgenc):
+#     bytecodes = method_to_bytecodes(
+#         mgenc,
+#         """
+#         test: arg1 with: arg2 = (
+#             #start.
+#             self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ].
+#             #end
+#         )""",
+#     )
+#
+#     dump(mgenc)
+#     assert len(bytecodes) == 1
+#
+#
+# def test_if_true_if_false_nlr_arg2(mgenc):
+#     bytecodes = method_to_bytecodes(
+#         mgenc,
+#         """
+#         test: arg1 with: arg2 = (
+#             #start.
+#             self method ifTrue: [ arg1 ] ifFalse: [ ^ arg2 ].
+#             #end
+#         )""",
+#     )
+#
+#     dump(mgenc)
+#     assert len(bytecodes) == 1
+#
+#
+# def test_if_true_if_false_return(mgenc):
+#     bytecodes = method_to_bytecodes(
+#         mgenc,
+#         """
+#         test: arg1 with: arg2 = (
+#             #start.
+#             ^ self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ]
+#         )""",
+#     )
+#
+#     dump(mgenc)
+#     assert len(bytecodes) == 1
+#
+#
+# def test_if_false_if_true_return(mgenc):
+#     bytecodes = method_to_bytecodes(
+#         mgenc,
+#         """
+#         test: arg1 with: arg2 = (
+#             #start.
+#             ^ self method ifFalse: [ ^ arg1 ] ifTrue: [ arg2 ]
+#         )""",
+#     )
+#
+#     dump(mgenc)
+#     assert len(bytecodes) == 1
 
 
 def test_if_push_constant_same(mgenc):

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -359,19 +359,16 @@ def test_if_return_non_local(mgenc, if_selector, jump_bytecode):
         ),
     )
 
-    assert len(bytecodes) == 18
+    assert len(bytecodes) == 17
     assert Bytecodes.send_1 == bytecodes[5]
     assert jump_bytecode == bytecodes[7]
-    assert bytecodes[8] == 7, "jump offset"
+    assert bytecodes[8] == 6, "jump offset"
 
     assert Bytecodes.push_argument == bytecodes[9]
     assert bytecodes[10] == 1, "arg idx"
     assert bytecodes[11] == 0, "ctx level"
     assert Bytecodes.return_local == bytecodes[12]
-    assert (
-        Bytecodes.halt == bytecodes[13]
-    ), "because the original return_non_local has length=2"
-    assert Bytecodes.pop == bytecodes[14]
+    assert Bytecodes.pop == bytecodes[13]
 
 
 def test_nested_ifs(cgenc, mgenc):
@@ -388,10 +385,10 @@ def test_nested_ifs(cgenc, mgenc):
         )""",
     )
 
-    assert len(bytecodes) == 19
+    assert len(bytecodes) == 18
     assert Bytecodes.push_global == bytecodes[0]
     assert Bytecodes.jump_on_false_top_nil == bytecodes[2]
-    assert bytecodes[3] == 16
+    assert bytecodes[3] == 15
     assert Bytecodes.jump_on_true_top_nil == bytecodes[6]
     assert Bytecodes.push_field == bytecodes[8]
     assert bytecodes[9] == 0, "field idx"
@@ -401,8 +398,7 @@ def test_nested_ifs(cgenc, mgenc):
     assert bytecodes[13] == 0, "ctx_level"
     assert Bytecodes.send_2 == bytecodes[14]
     assert Bytecodes.return_local == bytecodes[16]
-    assert Bytecodes.halt == bytecodes[17]
-    assert Bytecodes.return_self == bytecodes[18]
+    assert Bytecodes.return_self == bytecodes[17]
 
 
 def test_nested_ifs_and_locals(cgenc, mgenc):
@@ -423,7 +419,7 @@ def test_nested_ifs_and_locals(cgenc, mgenc):
               ^ i - j - f - g - d ] ] )""",
     )
 
-    assert len(bytecodes) == 54
+    assert len(bytecodes) == 53
     assert Bytecodes.push_local == bytecodes[0]
     assert bytecodes[1] == 1
     assert bytecodes[2] == 0
@@ -433,7 +429,7 @@ def test_nested_ifs_and_locals(cgenc, mgenc):
     assert bytecodes[5] == 0
 
     assert Bytecodes.jump_on_false_top_nil == bytecodes[8]
-    assert bytecodes[9] == 45, "jump offset"
+    assert bytecodes[9] == 44, "jump offset"
 
     assert Bytecodes.pop_local == bytecodes[12]
     assert bytecodes[13] == 4
@@ -444,7 +440,7 @@ def test_nested_ifs_and_locals(cgenc, mgenc):
     assert bytecodes[19] == 0
 
     assert Bytecodes.jump_on_true_top_nil == bytecodes[22]
-    assert bytecodes[23] == 31, "jump offset"
+    assert bytecodes[23] == 30, "jump offset"
 
     assert Bytecodes.pop_local == bytecodes[25]
     assert bytecodes[26] == 7
@@ -477,10 +473,10 @@ def test_nested_ifs_and_non_inlined_blocks(cgenc, mgenc):
         )""",
     )
 
-    assert len(bytecodes) == 35
+    assert len(bytecodes) == 34
     assert Bytecodes.push_global == bytecodes[4]
     assert Bytecodes.jump_on_false_top_nil == bytecodes[6]
-    assert bytecodes[7] == 25, "jump offset"
+    assert bytecodes[7] == 24, "jump offset"
     assert Bytecodes.pop_local == bytecodes[9]
     assert bytecodes[10] == 1, "e var idx"
     assert bytecodes[11] == 0, "e ctx idx"
@@ -491,7 +487,7 @@ def test_nested_ifs_and_non_inlined_blocks(cgenc, mgenc):
     assert block_method.get_bytecode(3) == 1, "a ctx level"
 
     assert Bytecodes.jump_on_true_top_nil == bytecodes[17]
-    assert bytecodes[18] == 14, "jump offset"
+    assert bytecodes[18] == 13, "jump offset"
 
     assert Bytecodes.pop_local == bytecodes[20]
     assert bytecodes[21] == 2, "h var idx"
@@ -510,7 +506,7 @@ def test_nested_ifs_and_non_inlined_blocks(cgenc, mgenc):
     assert block_method.get_bytecode(9) == 1, "e var idx"
     assert block_method.get_bytecode(10) == 1, "e ctx level"
 
-    block_method = mgenc.get_constant(32)
+    block_method = mgenc.get_constant(31)
     assert block_method.get_bytecode(0) == Bytecodes.push_local
     assert block_method.get_bytecode(1) == 0, "a var idx"
     assert block_method.get_bytecode(2) == 1, "a ctx level"
@@ -669,25 +665,24 @@ def test_if_true_if_false_nlr_arg1(mgenc):
         )""",
     )
 
-    assert len(bytecodes) == 23
+    assert len(bytecodes) == 22
     assert Bytecodes.jump_on_false_pop == bytecodes[7]
-    assert bytecodes[8] == 9, "jump offset"
+    assert bytecodes[8] == 8, "jump offset"
 
     assert Bytecodes.push_argument == bytecodes[9]
     assert bytecodes[10] == 1, "arg1 idx"
     assert bytecodes[11] == 0, "arg1 ctx level"
 
     assert Bytecodes.return_local == bytecodes[12]
-    assert Bytecodes.halt == bytecodes[13]
 
-    assert Bytecodes.jump == bytecodes[14]
-    assert bytecodes[15] == 5, "jump offset"
+    assert Bytecodes.jump == bytecodes[13]
+    assert bytecodes[14] == 5, "jump offset"
 
-    assert Bytecodes.push_argument == bytecodes[16]
-    assert bytecodes[17] == 2, "arg1 idx"
-    assert bytecodes[18] == 0, "arg1 ctx level"
+    assert Bytecodes.push_argument == bytecodes[15]
+    assert bytecodes[16] == 2, "arg1 idx"
+    assert bytecodes[17] == 0, "arg1 ctx level"
 
-    assert Bytecodes.pop == bytecodes[19]
+    assert Bytecodes.pop == bytecodes[18]
 
 
 def test_if_true_if_false_nlr_arg2(mgenc):
@@ -701,7 +696,7 @@ def test_if_true_if_false_nlr_arg2(mgenc):
         )""",
     )
 
-    assert len(bytecodes) == 23
+    assert len(bytecodes) == 22
     assert Bytecodes.jump_on_false_pop == bytecodes[7]
     assert bytecodes[8] == 7, "jump offset"
 
@@ -710,14 +705,14 @@ def test_if_true_if_false_nlr_arg2(mgenc):
     assert bytecodes[11] == 0, "arg1 ctx level"
 
     assert Bytecodes.jump == bytecodes[12]
-    assert bytecodes[13] == 7, "jump offset"
+    assert bytecodes[13] == 6, "jump offset"
 
     assert Bytecodes.push_argument == bytecodes[14]
     assert bytecodes[15] == 2, "arg1 idx"
     assert bytecodes[16] == 0, "arg1 ctx level"
 
     assert Bytecodes.return_local == bytecodes[17]
-    assert Bytecodes.pop == bytecodes[19]
+    assert Bytecodes.pop == bytecodes[18]
 
 
 @pytest.mark.parametrize(
@@ -741,12 +736,12 @@ def test_if_true_if_false_return(mgenc, sel1, sel2, jump_bytecode):
         ),
     )
 
-    assert len(bytecodes) == 20
+    assert len(bytecodes) == 19
     assert jump_bytecode == bytecodes[7]
-    assert bytecodes[8] == 9, "jump offset"
+    assert bytecodes[8] == 8, "jump offset"
 
-    assert Bytecodes.jump == bytecodes[14]
-    assert bytecodes[15] == 5, "jump offset"
+    assert Bytecodes.jump == bytecodes[13]
+    assert bytecodes[14] == 5, "jump offset"
 
 
 def test_if_push_constant_same(mgenc):
@@ -807,6 +802,23 @@ def test_if_push_constant_different(mgenc):
 
     assert Bytecodes.push_constant == bytecodes[22]
     assert bytecodes[23] == 9, "const idx"
+
+
+def test_if_inline_and_constant_bc_length(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test = (
+          #a. #b. #c.
+          true ifTrue: [
+            true ifFalse: [ #e. #f. #g ] ]
+        )""",
+    )
+
+    dump(mgenc)
+
+    assert Bytecodes.jump_on_true_top_nil == bytecodes[12]
+    assert bytecodes[13] == 10, "jump offset, should point to correct bytecode" + " and not be affected by changing length of bytecodes in the block"
 
 
 def test_block_dup_pop_argument_pop_return_arg(bgenc):

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -275,7 +275,6 @@ def test_keyword_if_true_arg(mgenc):
         )""",
     )
 
-    dump(mgenc)
     assert len(bytecodes) == 17
     assert Bytecodes.send_2 == bytecodes[6]
     assert Bytecodes.jump_on_false_top_nil == bytecodes[8]
@@ -360,7 +359,6 @@ def test_if_return_non_local(mgenc, if_selector, jump_bytecode):
         ),
     )
 
-    dump(mgenc)
     assert len(bytecodes) == 18
     assert Bytecodes.send_1 == bytecodes[5]
     assert jump_bytecode == bytecodes[7]
@@ -479,7 +477,6 @@ def test_nested_ifs_and_non_inlined_blocks(cgenc, mgenc):
         )""",
     )
 
-    dump(mgenc)
     assert len(bytecodes) == 35
     assert Bytecodes.push_global == bytecodes[4]
     assert Bytecodes.jump_on_false_top_nil == bytecodes[6]
@@ -534,7 +531,6 @@ def test_nested_non_inlined_blocks(cgenc, mgenc):
         )""",
     )
 
-    dump(mgenc)
     assert len(bytecodes) == 19
     assert Bytecodes.jump_on_true_top_nil == bytecodes[2]
     assert bytecodes[3] == 16, "jump offset"
@@ -599,7 +595,6 @@ def test_block_if_true_arg(bgenc):
         ]""",
     )
 
-    dump(bgenc)
     assert len(bytecodes) == 16
     assert Bytecodes.send_1 == bytecodes[5]
     assert Bytecodes.jump_on_false_top_nil == bytecodes[7]
@@ -623,7 +618,6 @@ def test_block_if_true_method_arg(mgenc, bgenc):
         ]""",
     )
 
-    dump(bgenc)
     assert len(bytecodes) == 16
     assert Bytecodes.jump_on_false_top_nil == bytecodes[7]
     assert bytecodes[8] == 5, "jump offset"
@@ -745,7 +739,6 @@ def test_if_push_constant_different(mgenc):
         )""",
     )
 
-    dump(mgenc)
     assert len(bytecodes) == 25
     assert Bytecodes.push_constant_0 == bytecodes[0]
     assert Bytecodes.push_constant_1 == bytecodes[2]

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -20,7 +20,7 @@ def add_field(cgenc, name):
 
 
 def dump(mgenc):
-    dump_method(mgenc, "")
+    dump_method(mgenc, b"")
 
 
 @pytest.fixture

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -809,8 +809,6 @@ def test_if_inline_and_constant_bc_length(mgenc):
         )""",
     )
 
-    dump(mgenc)
-
     assert Bytecodes.jump_on_true_top_nil == bytecodes[12]
     assert bytecodes[13] == 10, (
         "jump offset, should point to correct bytecode"

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -629,77 +629,124 @@ def test_block_if_true_method_arg(mgenc, bgenc):
     assert Bytecodes.push_constant == bytecodes[13]
 
 
-# def test_if_true_if_false_arg(mgenc):
-#     bytecodes = method_to_bytecodes(
-#         mgenc,
-#         """
-#         test: arg1 with: arg2 = (
-#             #start.
-#             self method ifTrue: [ arg1 ] ifFalse: [ arg2 ].
-#             #end
-#         )""",
-#     )
-#
-#     dump(mgenc)
-#     assert len(bytecodes) == 1
-#
-#
-# def test_if_true_if_false_nlr_arg1(mgenc):
-#     bytecodes = method_to_bytecodes(
-#         mgenc,
-#         """
-#         test: arg1 with: arg2 = (
-#             #start.
-#             self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ].
-#             #end
-#         )""",
-#     )
-#
-#     dump(mgenc)
-#     assert len(bytecodes) == 1
-#
-#
-# def test_if_true_if_false_nlr_arg2(mgenc):
-#     bytecodes = method_to_bytecodes(
-#         mgenc,
-#         """
-#         test: arg1 with: arg2 = (
-#             #start.
-#             self method ifTrue: [ arg1 ] ifFalse: [ ^ arg2 ].
-#             #end
-#         )""",
-#     )
-#
-#     dump(mgenc)
-#     assert len(bytecodes) == 1
-#
-#
-# def test_if_true_if_false_return(mgenc):
-#     bytecodes = method_to_bytecodes(
-#         mgenc,
-#         """
-#         test: arg1 with: arg2 = (
-#             #start.
-#             ^ self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ]
-#         )""",
-#     )
-#
-#     dump(mgenc)
-#     assert len(bytecodes) == 1
-#
-#
-# def test_if_false_if_true_return(mgenc):
-#     bytecodes = method_to_bytecodes(
-#         mgenc,
-#         """
-#         test: arg1 with: arg2 = (
-#             #start.
-#             ^ self method ifFalse: [ ^ arg1 ] ifTrue: [ arg2 ]
-#         )""",
-#     )
-#
-#     dump(mgenc)
-#     assert len(bytecodes) == 1
+def test_if_true_if_false_arg(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            self method ifTrue: [ arg1 ] ifFalse: [ arg2 ].
+            #end
+        )""",
+    )
+
+    assert len(bytecodes) == 21
+    assert Bytecodes.jump_on_false_pop == bytecodes[7]
+    assert bytecodes[8] == 7, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[9]
+    assert bytecodes[10] == 1, "arg1 idx"
+    assert bytecodes[11] == 0, "arg1 ctx level"
+
+    assert Bytecodes.jump == bytecodes[12]
+    assert bytecodes[13] == 5, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[14]
+    assert bytecodes[15] == 2, "arg1 idx"
+    assert bytecodes[16] == 0, "arg1 ctx level"
+
+    assert Bytecodes.pop == bytecodes[17]
+
+
+def test_if_true_if_false_nlr_arg1(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            self method ifTrue: [ ^ arg1 ] ifFalse: [ arg2 ].
+            #end
+        )""",
+    )
+
+    assert len(bytecodes) == 23
+    assert Bytecodes.jump_on_false_pop == bytecodes[7]
+    assert bytecodes[8] == 9, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[9]
+    assert bytecodes[10] == 1, "arg1 idx"
+    assert bytecodes[11] == 0, "arg1 ctx level"
+
+    assert Bytecodes.return_local == bytecodes[12]
+    assert Bytecodes.halt == bytecodes[13]
+
+    assert Bytecodes.jump == bytecodes[14]
+    assert bytecodes[15] == 5, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[16]
+    assert bytecodes[17] == 2, "arg1 idx"
+    assert bytecodes[18] == 0, "arg1 ctx level"
+
+    assert Bytecodes.pop == bytecodes[19]
+
+
+def test_if_true_if_false_nlr_arg2(mgenc):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            self method ifTrue: [ arg1 ] ifFalse: [ ^ arg2 ].
+            #end
+        )""",
+    )
+
+    assert len(bytecodes) == 23
+    assert Bytecodes.jump_on_false_pop == bytecodes[7]
+    assert bytecodes[8] == 7, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[9]
+    assert bytecodes[10] == 1, "arg1 idx"
+    assert bytecodes[11] == 0, "arg1 ctx level"
+
+    assert Bytecodes.jump == bytecodes[12]
+    assert bytecodes[13] == 7, "jump offset"
+
+    assert Bytecodes.push_argument == bytecodes[14]
+    assert bytecodes[15] == 2, "arg1 idx"
+    assert bytecodes[16] == 0, "arg1 ctx level"
+
+    assert Bytecodes.return_local == bytecodes[17]
+    assert Bytecodes.pop == bytecodes[19]
+
+
+@pytest.mark.parametrize(
+    "sel1,sel2,jump_bytecode",
+    [
+        ("ifTrue:", "ifFalse:", Bytecodes.jump_on_false_pop),
+        ("ifFalse:", "ifTrue:", Bytecodes.jump_on_true_pop),
+    ],
+)
+def test_if_true_if_false_return(mgenc, sel1, sel2, jump_bytecode):
+    bytecodes = method_to_bytecodes(
+        mgenc,
+        """
+        test: arg1 with: arg2 = (
+            #start.
+            ^ self method SEL1 [ ^ arg1 ] SEL2 [ arg2 ]
+        )""".replace(
+            "SEL1", sel1
+        ).replace(
+            "SEL2", sel2
+        ),
+    )
+
+    assert len(bytecodes) == 20
+    assert jump_bytecode == bytecodes[7]
+    assert bytecodes[8] == 9, "jump offset"
+
+    assert Bytecodes.jump == bytecodes[14]
+    assert bytecodes[15] == 5, "jump offset"
 
 
 def test_if_push_constant_same(mgenc):

--- a/tests/test_optimize_trivial.py
+++ b/tests/test_optimize_trivial.py
@@ -28,7 +28,7 @@ def add_field(cgenc, name):
 
 
 def dump(mgenc):
-    dump_method(mgenc, "")
+    dump_method(mgenc, b"")
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR brings inlining for the `#ifTrue*`/`#ifFalse:*` set of messages in the bytecode interpreter and the AST interpreter.
While we had AST-level replacement before, it didn't actually inline the blocks, which means it still required frame creation.

The bytecode interpreter is extended with jump bytecodes to support the inlining.

The performance gain is good throughout.
The AST interpreter sees a reduction of run time on the SomSom benchmarks by 4-6%.
The BC interpreter sees a reduction of 13-15%.

Startup sees a good benefit throughout as well. Recurse's JIT performance suffers, but that seems to be the recursive nature of it.

The overall difference between AST and BC interpreter on SomSom is now down to 9-13%.