### PR TITLE
Some simplifications, use symbols, make symbol table global, and remove second pass over bytecode

### DIFF
--- a/src/rlib/streamio.py
+++ b/src/rlib/streamio.py
@@ -4,7 +4,7 @@ except ImportError:
     "NOT_RPYTHON"
 
     def open_file_as_stream(file_name, mode):
-        return open(file_name, mode)
+        return open(file_name, mode)  # pylint: disable=unspecified-encoding
 
 
 # Taken from PyPy rpython/rlib/streamio.io (Version 7.3.1)

--- a/src/som/compiler/ast/method_generation_context.py
+++ b/src/som/compiler/ast/method_generation_context.py
@@ -21,7 +21,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
     def assemble(self, method_body):
         if self._primitive:
-            return empty_primitive(self.signature.get_embedded_string(), self.universe)
+            return empty_primitive(self.signature.get_embedded_string())
 
         if self.needs_to_catch_non_local_returns:
             method_body = CatchNonLocalReturnNode(

--- a/src/som/compiler/ast/parser.py
+++ b/src/som/compiler/ast/parser.py
@@ -21,6 +21,7 @@ from som.interpreter.ast.nodes.specialized.literal_if import (
     IfElseInlinedNode,
 )
 from som.interpreter.ast.nodes.specialized.literal_while import WhileInlinedNode
+from som.vm.symbols import symbol_for
 
 from som.vmobjects.array import Array
 from som.vmobjects.string import String
@@ -307,7 +308,7 @@ class Parser(ParserBase):
                     if inlined is not None:
                         return inlined
 
-        selector = self.universe.symbol_for(keyword)
+        selector = symbol_for(keyword)
 
         if is_super_send:
             num_args = len(arguments) + 1
@@ -372,7 +373,7 @@ class Parser(ParserBase):
         self._expect(Symbol.Pound)
         if self._sym == Symbol.STString:
             s = self._string()
-            return self.universe.symbol_for(s)
+            return symbol_for(s)
         return self._selector()
 
     def _literal_string(self):
@@ -394,14 +395,15 @@ class Parser(ParserBase):
         self._expect(Symbol.EndBlock)
         return expressions
 
-    def _variable_read(self, mgenc, variable_name):
+    @staticmethod
+    def _variable_read(mgenc, variable_name):
         # first lookup in local variables, or method arguments
         variable = mgenc.get_variable(variable_name)
         if variable:
             return variable.get_read_node(mgenc.get_context_level(variable_name))
 
         # otherwise, it might be an object field
-        var_symbol = self.universe.symbol_for(variable_name)
+        var_symbol = symbol_for(variable_name)
         field_read = mgenc.get_object_field_read(var_symbol)
         if field_read:
             return field_read
@@ -427,7 +429,7 @@ class Parser(ParserBase):
         if variable:
             return variable.get_write_node(mgenc.get_context_level(variable_name), exp)
 
-        field_name = self.universe.symbol_for(variable_name)
+        field_name = symbol_for(variable_name)
         field_write = mgenc.get_object_field_write(field_name, exp)
         if field_write:
             return field_write

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -218,3 +218,7 @@ def emit3_with_dummy(mgenc, code):
     idx = mgenc.add_bytecode_argument_and_get_index(0)
     mgenc.add_bytecode_argument(0)
     return idx
+
+
+def compute_offset(byte1, byte2):
+    return byte1 + (byte2 << 8)

--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -2,50 +2,46 @@ from som.interpreter.bc.bytecodes import Bytecodes as BC
 
 
 def emit_inc(mgenc):
-    emit1(mgenc, BC.inc)
+    emit1(mgenc, BC.inc, 0)
 
 
 def emit_dec(mgenc):
-    emit1(mgenc, BC.dec)
+    emit1(mgenc, BC.dec, 0)
 
 
 def emit_pop(mgenc):
     if not mgenc.optimize_dup_pop_pop_sequence():
-        emit1(mgenc, BC.pop)
+        emit1(mgenc, BC.pop, -1)
 
 
 def emit_push_argument(mgenc, idx, ctx):
-    emit3(mgenc, BC.push_argument, idx, ctx)
+    emit3(mgenc, BC.push_argument, idx, ctx, 1)
 
 
 def emit_return_self(mgenc):
     mgenc.optimize_dup_pop_pop_sequence()
-    emit1(mgenc, BC.return_self)
+    emit1(mgenc, BC.return_self, 0)
 
 
 def emit_return_local(mgenc):
-    emit1(mgenc, BC.return_local)
+    emit1(mgenc, BC.return_local, 0)
 
 
 def emit_return_non_local(mgenc):
-    emit2(mgenc, BC.return_non_local, mgenc.get_max_context_level())
+    emit2(mgenc, BC.return_non_local, mgenc.get_max_context_level(), 0)
 
 
 def emit_dup(mgenc):
-    emit1(mgenc, BC.dup)
+    emit1(mgenc, BC.dup, 1)
 
 
 def emit_push_block(mgenc, block_method, with_ctx):
     idx = mgenc.add_literal_if_absent(block_method)
-    emit2(
-        mgenc,
-        BC.push_block if with_ctx else BC.push_block_no_ctx,
-        idx,
-    )
+    emit2(mgenc, BC.push_block if with_ctx else BC.push_block_no_ctx, idx, 1)
 
 
 def emit_push_local(mgenc, idx, ctx):
-    emit3(mgenc, BC.push_local, idx, ctx)
+    emit3(mgenc, BC.push_local, idx, ctx, 1)
 
 
 def emit_push_field(mgenc, field_name):
@@ -58,18 +54,13 @@ def emit_push_field(mgenc, field_name):
 def emit_push_field_with_index(mgenc, field_idx, ctx_level):
     if ctx_level == 0:
         if field_idx == 0:
-            emit1(mgenc, BC.push_field_0)
+            emit1(mgenc, BC.push_field_0, 1)
             return
         if field_idx == 1:
-            emit1(mgenc, BC.push_field_1)
+            emit1(mgenc, BC.push_field_1, 1)
             return
 
-    emit3(
-        mgenc,
-        BC.push_field,
-        field_idx,
-        mgenc.get_max_context_level(),
-    )
+    emit3(mgenc, BC.push_field, field_idx, mgenc.get_max_context_level(), 1)
 
 
 def emit_push_global(mgenc, glob):
@@ -77,15 +68,15 @@ def emit_push_global(mgenc, glob):
     # the block needs to be able to send #unknownGlobal: to self
     if not mgenc.is_global_known(glob):
         mgenc.mark_self_as_accessed_from_outer_context()
-    emit2(mgenc, BC.push_global, idx)
+    emit2(mgenc, BC.push_global, idx, 1)
 
 
 def emit_pop_argument(mgenc, idx, ctx):
-    emit3(mgenc, BC.pop_argument, idx, ctx)
+    emit3(mgenc, BC.pop_argument, idx, ctx, -1)
 
 
 def emit_pop_local(mgenc, idx, ctx):
-    emit3(mgenc, BC.pop_local, idx, ctx)
+    emit3(mgenc, BC.pop_local, idx, ctx, -1)
 
 
 def emit_pop_field(mgenc, field_name):
@@ -97,35 +88,33 @@ def emit_pop_field(mgenc, field_name):
 def emit_pop_field_with_index(mgenc, field_idx, ctx_level):
     if ctx_level == 0:
         if field_idx == 0:
-            emit1(mgenc, BC.pop_field_0)
+            emit1(mgenc, BC.pop_field_0, -1)
             return
         if field_idx == 1:
-            emit1(mgenc, BC.pop_field_1)
+            emit1(mgenc, BC.pop_field_1, -1)
             return
-    emit3(
-        mgenc,
-        BC.pop_field,
-        field_idx,
-        ctx_level,
-    )
+    emit3(mgenc, BC.pop_field, field_idx, ctx_level, -1)
 
 
 def emit_super_send(mgenc, msg):
     idx = mgenc.add_literal_if_absent(msg)
-    emit2(mgenc, BC.super_send, idx)
+    stack_effect = -msg.get_number_of_signature_arguments() + 1  # +1 for the result
+    emit2(mgenc, BC.super_send, idx, stack_effect)
 
 
 def emit_send(mgenc, msg):
     idx = mgenc.add_literal_if_absent(msg)
     num_args = msg.get_number_of_signature_arguments()
+    stack_effect = -num_args + 1  # +1 for the result
+
     if num_args == 1:
-        emit2(mgenc, BC.send_1, idx)
+        emit2(mgenc, BC.send_1, idx, stack_effect)
     elif num_args == 2:
-        emit2(mgenc, BC.send_2, idx)
+        emit2(mgenc, BC.send_2, idx, stack_effect)
     elif num_args == 3:
-        emit2(mgenc, BC.send_3, idx)
+        emit2(mgenc, BC.send_3, idx, stack_effect)
     else:
-        emit2(mgenc, BC.send_n, idx)
+        emit2(mgenc, BC.send_n, idx, stack_effect)
 
 
 def emit_push_constant(mgenc, lit):
@@ -134,32 +123,32 @@ def emit_push_constant(mgenc, lit):
 
     if isinstance(lit, Integer):
         if lit.get_embedded_integer() == 0:
-            emit1(mgenc, BC.push_0)
+            emit1(mgenc, BC.push_0, 1)
             return
         if lit.get_embedded_integer() == 1:
-            emit1(mgenc, BC.push_1)
+            emit1(mgenc, BC.push_1, 1)
             return
 
     if lit is nilObject:
-        emit1(mgenc, BC.push_nil)
+        emit1(mgenc, BC.push_nil, 1)
         return
 
     idx = mgenc.add_literal_if_absent(lit)
     if idx == 0:
-        emit1(mgenc, BC.push_constant_0)
+        emit1(mgenc, BC.push_constant_0, 1)
         return
     if idx == 1:
-        emit1(mgenc, BC.push_constant_1)
+        emit1(mgenc, BC.push_constant_1, 1)
         return
     if idx == 2:
-        emit1(mgenc, BC.push_constant_2)
+        emit1(mgenc, BC.push_constant_2, 1)
         return
 
-    emit2(mgenc, BC.push_constant, idx)
+    emit2(mgenc, BC.push_constant, idx, 1)
 
 
 def emit_push_constant_index(mgenc, lit_index):
-    emit2(mgenc, BC.push_constant, lit_index)
+    emit2(mgenc, BC.push_constant, lit_index, 1)
 
 
 def emit_jump_on_bool_with_dummy_offset(mgenc, is_if_true, needs_pop):
@@ -167,18 +156,21 @@ def emit_jump_on_bool_with_dummy_offset(mgenc, is_if_true, needs_pop):
     # This is because if the test passes, the block is inlined directly.
     # But if the test fails, we need to jump.
     # Thus, an  `#ifTrue:` needs to generated a jump_on_false.
-    if is_if_true:
-        emit1(mgenc, BC.jump_on_false_pop if needs_pop else BC.jump_on_false_top_nil)
+    if needs_pop:
+        bc = BC.jump_on_false_pop if is_if_true else BC.jump_on_true_pop
+        stack_effect = -1
     else:
-        emit1(mgenc, BC.jump_on_true_pop if needs_pop else BC.jump_on_true_top_nil)
+        bc = BC.jump_on_false_top_nil if is_if_true else BC.jump_on_true_top_nil
+        stack_effect = 0
 
+    emit1(mgenc, bc, stack_effect)
     idx = mgenc.add_bytecode_argument_and_get_index(0)
     mgenc.add_bytecode_argument(0)
     return idx
 
 
 def emit_jump_with_dummy_offset(mgenc):
-    emit1(mgenc, BC.jump)
+    emit1(mgenc, BC.jump, 0)
     idx = mgenc.add_bytecode_argument_and_get_index(0)
     mgenc.add_bytecode_argument(0)
     return idx
@@ -190,31 +182,32 @@ def emit_jump_backward_with_offset(mgenc, offset):
         BC.jump_backward if offset <= 0xFF else BC.jump2_backward,
         offset & 0xFF,
         offset >> 8,
+        0,
     )
 
 
-def emit1(mgenc, code):
-    mgenc.add_bytecode(code)
+def emit1(mgenc, code, stack_effect):
+    mgenc.add_bytecode(code, stack_effect)
 
 
-def emit2(mgenc, code, idx):
-    mgenc.add_bytecode(code)
+def emit2(mgenc, code, idx, stack_effect):
+    mgenc.add_bytecode(code, stack_effect)
     mgenc.add_bytecode_argument(idx)
 
 
-def emit2_with_dummy(mgenc, code):
-    mgenc.add_bytecode(code)
+def emit2_with_dummy(mgenc, code, stack_effect):
+    mgenc.add_bytecode(code, stack_effect)
     return mgenc.add_bytecode_argument_and_get_index(0)
 
 
-def emit3(mgenc, code, idx, ctx):
-    mgenc.add_bytecode(code)
+def emit3(mgenc, code, idx, ctx, stack_effect):
+    mgenc.add_bytecode(code, stack_effect)
     mgenc.add_bytecode_argument(idx)
     mgenc.add_bytecode_argument(ctx)
 
 
-def emit3_with_dummy(mgenc, code):
-    mgenc.add_bytecode(code)
+def emit3_with_dummy(mgenc, code, stack_effect):
+    mgenc.add_bytecode(code, stack_effect)
     idx = mgenc.add_bytecode_argument_and_get_index(0)
     mgenc.add_bytecode_argument(0)
     return idx

--- a/src/som/compiler/bc/disassembler.py
+++ b/src/som/compiler/bc/disassembler.py
@@ -1,3 +1,4 @@
+from som.compiler.bc.bytecode_generator import compute_offset
 from som.vm.current import current_universe
 from som.vm.universe import error_print, error_println
 from som.interpreter.bc.bytecodes import (
@@ -181,10 +182,7 @@ def dump_bytecode(m, b, indent=""):
     elif bytecode == Bytecodes.return_non_local:
         error_println("context: " + str(m.get_bytecode(b + 1)))
     elif is_one_of(bytecode, JUMP_BYTECODES):
-        offset1 = m.get_bytecode(b + 1)
-        offset2 = m.get_bytecode(b + 2)
-        offset = offset1 + (offset2 << 8)
-
+        offset = compute_offset(m.get_bytecode(b + 1), m.get_bytecode(b + 2))
         if bytecode == Bytecodes.jump_backward or bytecode == Bytecodes.jump2_backward:
             target = b - offset
         else:

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -427,12 +427,11 @@ class MethodGenerationContext(MethodGenerationContextBase):
             global_name = self._literals[0]
             assert isinstance(global_name, Symbol)
 
-            glob = global_name.get_embedded_string()
-            if glob == "true":
+            if global_name is self.universe.sym_true:
                 return LiteralReturn(self.signature, trueObject)
-            if glob == "false":
+            if global_name is self.universe.sym_false:
                 return LiteralReturn(self.signature, falseObject)
-            if glob == "nil":
+            if global_name is self.universe.sym_nil:
                 from som.vm.globals import nilObject
 
                 return LiteralReturn(self.signature, nilObject)

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -10,8 +10,6 @@ from som.compiler.bc.bytecode_generator import (
 from som.compiler.method_generation_context import MethodGenerationContextBase
 from som.compiler.parse_error import ParseError
 from som.interpreter.bc.bytecodes import (
-    bytecode_stack_effect,
-    bytecode_stack_effect_depends_on_send,
     bytecode_length,
     Bytecodes,
     POP_X_BYTECODES,
@@ -25,6 +23,7 @@ from som.interpreter.bc.bytecodes import (
     NUM_SINGLE_BYTE_JUMP_BYTECODES,
     FIRST_DOUBLE_BYTE_JUMP_BYTECODE,
 )
+from som.vm.symbols import sym_nil, sym_false, sym_true
 from som.vmobjects.integer import int_0, int_1
 from som.vmobjects.method_trivial import (
     LiteralReturn,
@@ -123,7 +122,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
     def assemble(self, _dummy):
         if self._primitive:
-            return empty_primitive(self.signature.get_embedded_string(), self.universe)
+            return empty_primitive(self.signature.get_embedded_string())
 
         trivial_method = self.assemble_trivial_method()
         if trivial_method is not None:
@@ -411,11 +410,11 @@ class MethodGenerationContext(MethodGenerationContextBase):
             global_name = self._literals[0]
             assert isinstance(global_name, Symbol)
 
-            if global_name is self.universe.sym_true:
+            if global_name is sym_true:
                 return LiteralReturn(self.signature, trueObject)
-            if global_name is self.universe.sym_false:
+            if global_name is sym_false:
                 return LiteralReturn(self.signature, falseObject)
-            if global_name is self.universe.sym_nil:
+            if global_name is sym_nil:
                 from som.vm.globals import nilObject
 
                 return LiteralReturn(self.signature, nilObject)

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -667,6 +667,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
         if jump_offset <= 0xFF:
             self._bytecode[idx_of_offset] = jump_offset
+            self._bytecode[idx_of_offset + 1] = 0
         else:
             # need to use the jump2* version of the bytecode
             if bytecode < FIRST_DOUBLE_BYTE_JUMP_BYTECODE:

--- a/src/som/compiler/class_generation_context.py
+++ b/src/som/compiler/class_generation_context.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+from som.vm.symbols import symbol_for
 from som.vmobjects.array import Array
 from som.vmobjects.clazz import Class
 
@@ -98,7 +99,7 @@ class ClassGenerationContext(object):
         result_class.set_instance_invokables(
             self._class_methods, self._class_has_primitives
         )
-        result_class.set_name(self.universe.symbol_for(cc_name))
+        result_class.set_name(symbol_for(cc_name))
 
         super_m_class = self._super_class.get_class(self.universe)
         result_class.set_super_class(super_m_class)

--- a/src/som/compiler/method_generation_context.py
+++ b/src/som/compiler/method_generation_context.py
@@ -6,6 +6,7 @@ from som.compiler.lexical_scope import LexicalScope
 from som.compiler.parse_error import ParseError
 from som.compiler.symbol import Symbol
 from som.interpreter.ast.frame import ARG_OFFSET, FRAME_AND_INNER_RCVR_IDX
+from som.vm.symbols import sym_nil, sym_false, sym_true, symbol_for
 
 
 class MethodGenerationContextBase(object):
@@ -116,9 +117,9 @@ class MethodGenerationContextBase(object):
 
     def is_global_known(self, global_name):
         return (
-            global_name is self.universe.sym_true
-            or global_name is self.universe.sym_false
-            or global_name is self.universe.sym_nil
+            global_name is sym_true
+            or global_name is sym_false
+            or global_name is sym_nil
             or self.universe.has_global(global_name)
         )
 
@@ -208,7 +209,7 @@ class MethodGenerationContextBase(object):
         for _ in range(num_args - 1):
             block_sig += ":"
 
-        self.signature = self.universe.symbol_for(block_sig)
+        self.signature = symbol_for(block_sig)
 
     def merge_into_scope(self, scope_to_be_inlined):
         assert len(scope_to_be_inlined.arguments) == 1

--- a/src/som/compiler/method_generation_context.py
+++ b/src/som/compiler/method_generation_context.py
@@ -115,11 +115,10 @@ class MethodGenerationContextBase(object):
         )
 
     def is_global_known(self, global_name):
-        glob = global_name.get_embedded_string()
         return (
-            glob == "true"
-            or glob == "false"
-            or glob == "nil"
+            global_name is self.universe.sym_true
+            or global_name is self.universe.sym_false
+            or global_name is self.universe.sym_nil
             or self.universe.has_global(global_name)
         )
 

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -6,6 +6,7 @@ from som.compiler.parse_error import ParseError, ParseErrorSymList
 from som.compiler.symbol import Symbol
 
 from som.interp_type import is_ast_interpreter
+from som.vm.symbols import sym_object, symbol_for, sym_nil
 from som.vmobjects.double import Double
 
 if is_ast_interpreter():
@@ -77,7 +78,7 @@ class ParserBase(object):
         )
 
     def classdef(self, cgenc):
-        cgenc.name = self.universe.symbol_for(self._text)
+        cgenc.name = symbol_for(self._text)
         self._expect(Symbol.Identifier)
         self._expect(Symbol.Equal)
 
@@ -118,13 +119,13 @@ class ParserBase(object):
 
     def _superclass(self, cgenc):
         if self._sym == Symbol.Identifier:
-            super_name = self.universe.symbol_for(self._text)
+            super_name = symbol_for(self._text)
             self._accept(Symbol.Identifier)
         else:
-            super_name = self.universe.symbol_for("Object")
+            super_name = sym_object
 
         # Load the super class, if it is not nil (break the dependency cycle)
-        if super_name is not self.universe.sym_nil:
+        if super_name is not sym_nil:
             super_class = self.universe.load_class(super_name)
             if not super_class:
                 raise ParseError(
@@ -173,14 +174,14 @@ class ParserBase(object):
         if self._accept(Symbol.Or):
             while self._sym_is_identifier():
                 var = self._variable()
-                cgenc.add_instance_field(self.universe.symbol_for(var))
+                cgenc.add_instance_field(symbol_for(var))
             self._expect(Symbol.Or)
 
     def _class_fields(self, cgenc):
         if self._accept(Symbol.Or):
             while self._sym_is_identifier():
                 var = self._variable()
-                cgenc.add_class_field(self.universe.symbol_for(var))
+                cgenc.add_class_field(symbol_for(var))
             self._expect(Symbol.Or)
 
     def _pattern(self, mgenc):
@@ -209,10 +210,10 @@ class ParserBase(object):
             coord = self._lexer.get_source_coordinate()
             mgenc.add_argument(self._argument(), self._get_source_section(coord), self)
 
-        mgenc.signature = self.universe.symbol_for(keyword)
+        mgenc.signature = symbol_for(keyword)
 
     def _unary_selector(self):
-        return self.universe.symbol_for(self._identifier())
+        return symbol_for(self._identifier())
 
     def _binary_selector(self):
         s = self._text
@@ -232,7 +233,7 @@ class ParserBase(object):
         else:
             self._expect(Symbol.NONE)
 
-        return self.universe.symbol_for(s)
+        return symbol_for(s)
 
     def _identifier(self):
         s = self._text
@@ -343,7 +344,7 @@ class ParserBase(object):
     def _keyword_selector(self):
         s = self._text
         self._expect_one_of(self._keyword_selector_syms)
-        symb = self.universe.symbol_for(s)
+        symb = symbol_for(s)
         return symb
 
     def _string(self):

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -124,7 +124,7 @@ class ParserBase(object):
             super_name = self.universe.symbol_for("Object")
 
         # Load the super class, if it is not nil (break the dependency cycle)
-        if super_name.get_embedded_string() != "nil":
+        if super_name is not self.universe.sym_nil:
             super_class = self.universe.load_class(super_name)
             if not super_class:
                 raise ParseError(

--- a/src/som/interpreter/ast/nodes/dispatch.py
+++ b/src/som/interpreter/ast/nodes/dispatch.py
@@ -1,4 +1,5 @@
 from som.interpreter.send import lookup_and_send_3
+from som.vm.symbols import symbol_for
 
 from som.vmobjects.array import Array
 
@@ -93,7 +94,7 @@ class CachedDnuNode(_AbstractDispatchNode):
 
     _immutable_fields_ = ["_selector", "_cached_method"]
 
-    def __init__(self, selector, layout, next_entry, universe):
+    def __init__(self, selector, layout, next_entry):
         _AbstractDispatchNode.__init__(
             self,
             layout,
@@ -101,7 +102,7 @@ class CachedDnuNode(_AbstractDispatchNode):
         )
         self._selector = selector
         self._cached_method = layout.lookup_invokable(
-            universe.symbol_for("doesNotUnderstand:arguments:")
+            symbol_for("doesNotUnderstand:arguments:")
         )
 
     def dispatch_1(self, rcvr):

--- a/src/som/interpreter/ast/nodes/global_read_node.py
+++ b/src/som/interpreter/ast/nodes/global_read_node.py
@@ -4,15 +4,16 @@ from som.interpreter.send import lookup_and_send_2
 from som.vm.globals import nilObject, trueObject, falseObject
 
 from som.interpreter.ast.nodes.expression_node import ExpressionNode
+from som.vm.symbols import sym_false, sym_true, sym_nil
 from som.vmobjects.method_trivial import GlobalRead
 
 
 def create_global_node(global_name, universe, mgenc, source_section):
-    if global_name is universe.sym_true:
+    if global_name is sym_true:
         return LiteralNode(trueObject, source_section)
-    if global_name is universe.sym_false:
+    if global_name is sym_false:
         return LiteralNode(falseObject, source_section)
-    if global_name is universe.sym_nil:
+    if global_name is sym_nil:
         return LiteralNode(nilObject, source_section)
 
     assoc = universe.get_globals_association_or_none(global_name)

--- a/src/som/interpreter/ast/nodes/global_read_node.py
+++ b/src/som/interpreter/ast/nodes/global_read_node.py
@@ -8,12 +8,11 @@ from som.vmobjects.method_trivial import GlobalRead
 
 
 def create_global_node(global_name, universe, mgenc, source_section):
-    glob = global_name.get_embedded_string()
-    if glob == "true":
+    if global_name is universe.sym_true:
         return LiteralNode(trueObject, source_section)
-    if glob == "false":
+    if global_name is universe.sym_false:
         return LiteralNode(falseObject, source_section)
-    if glob == "nil":
+    if global_name is universe.sym_nil:
         return LiteralNode(nilObject, source_section)
 
     assoc = universe.get_globals_association_or_none(global_name)

--- a/src/som/interpreter/ast/nodes/message/generic_node.py
+++ b/src/som/interpreter/ast/nodes/message/generic_node.py
@@ -70,9 +70,7 @@ class _AbstractGenericMessageNode(ExpressionNode):
             if method is not None:
                 node = CachedDispatchNode(layout, method, self._dispatch)
             else:
-                node = CachedDnuNode(
-                    self._selector, layout, self._dispatch, self.universe
-                )
+                node = CachedDnuNode(self._selector, layout, self._dispatch)
 
             node.parent = self
             self._dispatch = node

--- a/src/som/interpreter/send.py
+++ b/src/som/interpreter/send.py
@@ -1,7 +1,10 @@
+from som.vm.symbols import symbol_for
+
+
 def lookup_and_send_2(receiver, arg, selector_string):
     from som.vm.current import current_universe
 
-    selector = current_universe.symbol_for(selector_string)
+    selector = symbol_for(selector_string)
     invokable = receiver.get_class(current_universe).lookup_invokable(selector)
 
     return invokable.invoke_2(receiver, arg)
@@ -10,6 +13,6 @@ def lookup_and_send_2(receiver, arg, selector_string):
 def lookup_and_send_3(receiver, arg1, arg2, selector_string):
     from som.vm.current import current_universe
 
-    selector = current_universe.symbol_for(selector_string)
+    selector = symbol_for(selector_string)
     invokable = receiver.get_class(current_universe).lookup_invokable(selector)
     return invokable.invoke_3(receiver, arg1, arg2)

--- a/src/som/primitives/array_primitives.py
+++ b/src/som/primitives/array_primitives.py
@@ -97,21 +97,13 @@ def _put_all(rcvr, arg):
 
 class ArrayPrimitivesBase(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(BinaryPrimitive("at:", self.universe, _at))
-        self._install_instance_primitive(
-            TernaryPrimitive("at:put:", self.universe, _at_put)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("length", self.universe, _length)
-        )
-        self._install_instance_primitive(UnaryPrimitive("copy", self.universe, _copy))
+        self._install_instance_primitive(BinaryPrimitive("at:", _at))
+        self._install_instance_primitive(TernaryPrimitive("at:put:", _at_put))
+        self._install_instance_primitive(UnaryPrimitive("length", _length))
+        self._install_instance_primitive(UnaryPrimitive("copy", _copy))
 
-        self._install_class_primitive(BinaryPrimitive("new:", self.universe, _new))
+        self._install_class_primitive(BinaryPrimitive("new:", _new))
 
-        self._install_instance_primitive(
-            BinaryPrimitive("doIndexes:", self.universe, _do_indexes)
-        )
-        self._install_instance_primitive(BinaryPrimitive("do:", self.universe, _do))
-        self._install_instance_primitive(
-            BinaryPrimitive("putAll:", self.universe, _put_all)
-        )
+        self._install_instance_primitive(BinaryPrimitive("doIndexes:", _do_indexes))
+        self._install_instance_primitive(BinaryPrimitive("do:", _do))
+        self._install_instance_primitive(BinaryPrimitive("putAll:", _put_all))

--- a/src/som/primitives/ast/block_primitives.py
+++ b/src/som/primitives/ast/block_primitives.py
@@ -12,4 +12,4 @@ def _restart(ivkbl, rcvr, args):
 
 class BlockPrimitives(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(Primitive("restart", self.universe, _restart))
+        self._install_instance_primitive(Primitive("restart", _restart))

--- a/src/som/primitives/ast/method_primitives.py
+++ b/src/som/primitives/ast/method_primitives.py
@@ -21,6 +21,4 @@ def _invoke_on_with(_ivkbl, rcvr, args):
 class MethodPrimitives(_Base):
     def install_primitives(self):
         _Base.install_primitives(self)
-        self._install_instance_primitive(
-            Primitive("invokeOn:with:", self.universe, _invoke_on_with)
-        )
+        self._install_instance_primitive(Primitive("invokeOn:with:", _invoke_on_with))

--- a/src/som/primitives/ast/primitive_primitives.py
+++ b/src/som/primitives/ast/primitive_primitives.py
@@ -20,6 +20,4 @@ def _invoke_on_with(_ivkbl, rcvr, args):
 class PrimitivePrimitives(_Base):
     def install_primitives(self):
         _Base.install_primitives(self)
-        self._install_instance_primitive(
-            Primitive("invokeOn:with:", self.universe, _invoke_on_with)
-        )
+        self._install_instance_primitive(Primitive("invokeOn:with:", _invoke_on_with))

--- a/src/som/primitives/bc/block_primitives.py
+++ b/src/som/primitives/bc/block_primitives.py
@@ -56,9 +56,5 @@ def _while_true(rcvr, arg):
 
 class BlockPrimitives(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(
-            BinaryPrimitive("whileTrue:", self.universe, _while_true)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("whileFalse:", self.universe, _while_false)
-        )
+        self._install_instance_primitive(BinaryPrimitive("whileTrue:", _while_true))
+        self._install_instance_primitive(BinaryPrimitive("whileFalse:", _while_false))

--- a/src/som/primitives/bc/integer_primitives.py
+++ b/src/som/primitives/bc/integer_primitives.py
@@ -108,9 +108,5 @@ def _to_by_do(_ivkbl, stack, stack_ptr):
 class IntegerPrimitives(_Base):
     def install_primitives(self):
         _Base.install_primitives(self)
-        self._install_instance_primitive(
-            TernaryPrimitive("to:do:", self.universe, _to_do)
-        )
-        self._install_instance_primitive(
-            Primitive("to:by:do:", self.universe, _to_by_do)
-        )
+        self._install_instance_primitive(TernaryPrimitive("to:do:", _to_do))
+        self._install_instance_primitive(Primitive("to:by:do:", _to_by_do))

--- a/src/som/primitives/class_primitives.py
+++ b/src/som/primitives/class_primitives.py
@@ -25,14 +25,8 @@ def _fields(rcvr):
 
 class ClassPrimitives(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(UnaryPrimitive("new", self.universe, _new))
-        self._install_instance_primitive(UnaryPrimitive("name", self.universe, _name))
-        self._install_instance_primitive(
-            UnaryPrimitive("superclass", self.universe, _super_class)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("methods", self.universe, _methods)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("fields", self.universe, _fields)
-        )
+        self._install_instance_primitive(UnaryPrimitive("new", _new))
+        self._install_instance_primitive(UnaryPrimitive("name", _name))
+        self._install_instance_primitive(UnaryPrimitive("superclass", _super_class))
+        self._install_instance_primitive(UnaryPrimitive("methods", _methods))
+        self._install_instance_primitive(UnaryPrimitive("fields", _fields))

--- a/src/som/primitives/double_primitives.py
+++ b/src/som/primitives/double_primitives.py
@@ -111,51 +111,31 @@ def _from_string(_rcvr, string):
 
 class DoublePrimitives(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(
-            UnaryPrimitive("asString", self.universe, _as_string)
-        )
-        self._install_instance_primitive(UnaryPrimitive("round", self.universe, _round))
-        self._install_instance_primitive(
-            UnaryPrimitive("asInteger", self.universe, _as_integer)
-        )
+        self._install_instance_primitive(UnaryPrimitive("asString", _as_string))
+        self._install_instance_primitive(UnaryPrimitive("round", _round))
+        self._install_instance_primitive(UnaryPrimitive("asInteger", _as_integer))
 
-        self._install_instance_primitive(UnaryPrimitive("sqrt", self.universe, _sqrt))
-        self._install_instance_primitive(BinaryPrimitive("+", self.universe, _plus))
-        self._install_instance_primitive(BinaryPrimitive("-", self.universe, _minus))
-        self._install_instance_primitive(BinaryPrimitive("*", self.universe, _mult))
-        self._install_instance_primitive(
-            BinaryPrimitive("//", self.universe, _double_div)
-        )
-        self._install_instance_primitive(BinaryPrimitive("%", self.universe, _mod))
-        self._install_instance_primitive(BinaryPrimitive("=", self.universe, _equals))
-        self._install_instance_primitive(
-            BinaryPrimitive("<", self.universe, _less_than)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("<=", self.universe, _less_than_or_equal)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive(">", self.universe, _greater_than)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive(">=", self.universe, _greater_than_or_equal)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("<>", self.universe, _unequals)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("~=", self.universe, _unequals)
-        )
+        self._install_instance_primitive(UnaryPrimitive("sqrt", _sqrt))
+        self._install_instance_primitive(BinaryPrimitive("+", _plus))
+        self._install_instance_primitive(BinaryPrimitive("-", _minus))
+        self._install_instance_primitive(BinaryPrimitive("*", _mult))
+        self._install_instance_primitive(BinaryPrimitive("//", _double_div))
+        self._install_instance_primitive(BinaryPrimitive("%", _mod))
+        self._install_instance_primitive(BinaryPrimitive("=", _equals))
+        self._install_instance_primitive(BinaryPrimitive("<", _less_than))
+        self._install_instance_primitive(BinaryPrimitive("<=", _less_than_or_equal))
+        self._install_instance_primitive(BinaryPrimitive(">", _greater_than))
+        self._install_instance_primitive(BinaryPrimitive(">=", _greater_than_or_equal))
+        self._install_instance_primitive(BinaryPrimitive("<>", _unequals))
+        self._install_instance_primitive(BinaryPrimitive("~=", _unequals))
 
-        self._install_instance_primitive(BinaryPrimitive("max:", self.universe, _max))
-        self._install_instance_primitive(BinaryPrimitive("min:", self.universe, _min))
+        self._install_instance_primitive(BinaryPrimitive("max:", _max))
+        self._install_instance_primitive(BinaryPrimitive("min:", _min))
 
-        self._install_instance_primitive(UnaryPrimitive("sin", self.universe, _sin))
-        self._install_instance_primitive(UnaryPrimitive("cos", self.universe, _cos))
+        self._install_instance_primitive(UnaryPrimitive("sin", _sin))
+        self._install_instance_primitive(UnaryPrimitive("cos", _cos))
 
         self._install_class_primitive(
-            UnaryPrimitive("PositiveInfinity", self.universe, _positive_infinity)
+            UnaryPrimitive("PositiveInfinity", _positive_infinity)
         )
-        self._install_class_primitive(
-            BinaryPrimitive("fromString:", self.universe, _from_string)
-        )
+        self._install_class_primitive(BinaryPrimitive("fromString:", _from_string))

--- a/src/som/primitives/false_primitives.py
+++ b/src/som/primitives/false_primitives.py
@@ -37,20 +37,14 @@ def _if_true_if_false(_rcvr, _true_block, false_block):
 
 class FalsePrimitivesBase(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(UnaryPrimitive("not", self.universe, _not))
-        self._install_instance_primitive(BinaryPrimitive("and:", self.universe, _and))
-        self._install_instance_primitive(BinaryPrimitive("&&", self.universe, _and))
+        self._install_instance_primitive(UnaryPrimitive("not", _not))
+        self._install_instance_primitive(BinaryPrimitive("and:", _and))
+        self._install_instance_primitive(BinaryPrimitive("&&", _and))
+
+        self._install_instance_primitive(BinaryPrimitive("or:", _or_and_if_false))
+        self._install_instance_primitive(BinaryPrimitive("||", _or_and_if_false))
+        self._install_instance_primitive(BinaryPrimitive("ifFalse:", _or_and_if_false))
 
         self._install_instance_primitive(
-            BinaryPrimitive("or:", self.universe, _or_and_if_false)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("||", self.universe, _or_and_if_false)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("ifFalse:", self.universe, _or_and_if_false)
-        )
-
-        self._install_instance_primitive(
-            TernaryPrimitive("ifTrue:ifFalse:", self.universe, _if_true_if_false)
+            TernaryPrimitive("ifTrue:ifFalse:", _if_true_if_false)
         )

--- a/src/som/primitives/integer_primitives.py
+++ b/src/som/primitives/integer_primitives.py
@@ -196,76 +196,44 @@ def _from_string(_rcvr, param):
 
 class IntegerPrimitivesBase(Primitives):
     def install_primitives(self):
+        self._install_instance_primitive(UnaryPrimitive("asString", _as_string))
+        self._install_instance_primitive(UnaryPrimitive("asDouble", _as_double))
         self._install_instance_primitive(
-            UnaryPrimitive("asString", self.universe, _as_string)
+            UnaryPrimitive("as32BitSignedValue", _as_32_bit_signed_value)
         )
         self._install_instance_primitive(
-            UnaryPrimitive("asDouble", self.universe, _as_double)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("as32BitSignedValue", self.universe, _as_32_bit_signed_value)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive(
-                "as32BitUnsignedValue", self.universe, _as_32_bit_unsigned_value
-            )
+            UnaryPrimitive("as32BitUnsignedValue", _as_32_bit_unsigned_value)
         )
 
-        self._install_instance_primitive(UnaryPrimitive("sqrt", self.universe, _sqrt))
+        self._install_instance_primitive(UnaryPrimitive("sqrt", _sqrt))
 
-        self._install_instance_primitive(BinaryPrimitive("+", self.universe, _plus))
-        self._install_instance_primitive(BinaryPrimitive("-", self.universe, _minus))
+        self._install_instance_primitive(BinaryPrimitive("+", _plus))
+        self._install_instance_primitive(BinaryPrimitive("-", _minus))
 
-        self._install_instance_primitive(BinaryPrimitive("*", self.universe, _multiply))
-        self._install_instance_primitive(
-            BinaryPrimitive("//", self.universe, _double_div)
-        )
-        self._install_instance_primitive(BinaryPrimitive("/", self.universe, _int_div))
-        self._install_instance_primitive(BinaryPrimitive("%", self.universe, _mod))
-        self._install_instance_primitive(
-            BinaryPrimitive("rem:", self.universe, _remainder)
-        )
-        self._install_instance_primitive(BinaryPrimitive("&", self.universe, _and))
+        self._install_instance_primitive(BinaryPrimitive("*", _multiply))
+        self._install_instance_primitive(BinaryPrimitive("//", _double_div))
+        self._install_instance_primitive(BinaryPrimitive("/", _int_div))
+        self._install_instance_primitive(BinaryPrimitive("%", _mod))
+        self._install_instance_primitive(BinaryPrimitive("rem:", _remainder))
+        self._install_instance_primitive(BinaryPrimitive("&", _and))
 
-        self._install_instance_primitive(
-            BinaryPrimitive("==", self.universe, _equals_equals)
-        )
+        self._install_instance_primitive(BinaryPrimitive("==", _equals_equals))
 
-        self._install_instance_primitive(BinaryPrimitive("=", self.universe, _equals))
-        self._install_instance_primitive(
-            BinaryPrimitive("<", self.universe, _less_than)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("<=", self.universe, _less_than_or_equal)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive(">", self.universe, _greater_than)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive(">=", self.universe, _greater_than_or_equal)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("<>", self.universe, _unequals)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("~=", self.universe, _unequals)
-        )
+        self._install_instance_primitive(BinaryPrimitive("=", _equals))
+        self._install_instance_primitive(BinaryPrimitive("<", _less_than))
+        self._install_instance_primitive(BinaryPrimitive("<=", _less_than_or_equal))
+        self._install_instance_primitive(BinaryPrimitive(">", _greater_than))
+        self._install_instance_primitive(BinaryPrimitive(">=", _greater_than_or_equal))
+        self._install_instance_primitive(BinaryPrimitive("<>", _unequals))
+        self._install_instance_primitive(BinaryPrimitive("~=", _unequals))
 
-        self._install_instance_primitive(
-            BinaryPrimitive("<<", self.universe, _left_shift)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("bitXor:", self.universe, _bit_xor)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive(">>>", self.universe, _unsigned_right_shift)
-        )
-        self._install_instance_primitive(UnaryPrimitive("abs", self.universe, _abs))
-        self._install_instance_primitive(BinaryPrimitive("max:", self.universe, _max))
-        self._install_instance_primitive(BinaryPrimitive("min:", self.universe, _min))
+        self._install_instance_primitive(BinaryPrimitive("<<", _left_shift))
+        self._install_instance_primitive(BinaryPrimitive("bitXor:", _bit_xor))
+        self._install_instance_primitive(BinaryPrimitive(">>>", _unsigned_right_shift))
+        self._install_instance_primitive(UnaryPrimitive("abs", _abs))
+        self._install_instance_primitive(BinaryPrimitive("max:", _max))
+        self._install_instance_primitive(BinaryPrimitive("min:", _min))
 
-        self._install_instance_primitive(BinaryPrimitive("to:", self.universe, _to))
+        self._install_instance_primitive(BinaryPrimitive("to:", _to))
 
-        self._install_class_primitive(
-            BinaryPrimitive("fromString:", self.universe, _from_string)
-        )
+        self._install_class_primitive(BinaryPrimitive("fromString:", _from_string))

--- a/src/som/primitives/invokable_primitives.py
+++ b/src/som/primitives/invokable_primitives.py
@@ -12,9 +12,5 @@ def _signature(rcvr):
 
 class InvokablePrimitivesBase(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(
-            UnaryPrimitive("holder", self.universe, _holder)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("signature", self.universe, _signature)
-        )
+        self._install_instance_primitive(UnaryPrimitive("holder", _holder))
+        self._install_instance_primitive(UnaryPrimitive("signature", _signature))

--- a/src/som/primitives/object_primitives.py
+++ b/src/som/primitives/object_primitives.py
@@ -85,36 +85,24 @@ def _perform_with_arguments(rcvr, selector, args):
 
 class ObjectPrimitivesBase(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(BinaryPrimitive("==", self.universe, _equals))
+        self._install_instance_primitive(BinaryPrimitive("==", _equals))
+        self._install_instance_primitive(UnaryPrimitive("hashcode", _hashcode))
+        self._install_instance_primitive(UnaryPrimitive("objectSize", _object_size))
+        self._install_instance_primitive(BinaryPrimitive("instVarAt:", _inst_var_at))
         self._install_instance_primitive(
-            UnaryPrimitive("hashcode", self.universe, _hashcode)
+            TernaryPrimitive("instVarAt:put:", _inst_var_at_put)
         )
         self._install_instance_primitive(
-            UnaryPrimitive("objectSize", self.universe, _object_size)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("instVarAt:", self.universe, _inst_var_at)
-        )
-        self._install_instance_primitive(
-            TernaryPrimitive("instVarAt:put:", self.universe, _inst_var_at_put)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("instVarNamed:", self.universe, _inst_var_named)
+            BinaryPrimitive("instVarNamed:", _inst_var_named)
         )
 
-        self._install_instance_primitive(UnaryPrimitive("halt", self.universe, _halt))
-        self._install_instance_primitive(UnaryPrimitive("class", self.universe, _class))
+        self._install_instance_primitive(UnaryPrimitive("halt", _halt))
+        self._install_instance_primitive(UnaryPrimitive("class", _class))
 
+        self._install_instance_primitive(BinaryPrimitive("perform:", _perform))
         self._install_instance_primitive(
-            BinaryPrimitive("perform:", self.universe, _perform)
+            TernaryPrimitive("perform:inSuperclass:", _perform_in_superclass)
         )
         self._install_instance_primitive(
-            TernaryPrimitive(
-                "perform:inSuperclass:", self.universe, _perform_in_superclass
-            )
-        )
-        self._install_instance_primitive(
-            TernaryPrimitive(
-                "perform:withArguments:", self.universe, _perform_with_arguments
-            )
+            TernaryPrimitive("perform:withArguments:", _perform_with_arguments)
         )

--- a/src/som/primitives/string_primitives.py
+++ b/src/som/primitives/string_primitives.py
@@ -1,9 +1,9 @@
 from rlib.objectmodel import compute_hash
 from som.compiler.symbol import Symbol
 from som.primitives.primitives import Primitives
-from som.vm.current import current_universe
 
 from som.vm.globals import trueObject, falseObject
+from som.vm.symbols import symbol_for
 from som.vmobjects.integer import Integer
 from som.vmobjects.primitive import UnaryPrimitive, BinaryPrimitive, TernaryPrimitive
 from som.vmobjects.string import String
@@ -14,7 +14,7 @@ def _concat(rcvr, argument):
 
 
 def _as_symbol(rcvr):
-    return current_universe.symbol_for(rcvr.get_embedded_string())
+    return symbol_for(rcvr.get_embedded_string())
 
 
 def _length(rcvr):
@@ -85,29 +85,15 @@ def _is_digits(self):
 
 class StringPrimitivesBase(Primitives):
     def install_primitives(self):
+        self._install_instance_primitive(BinaryPrimitive("concatenate:", _concat))
+        self._install_instance_primitive(UnaryPrimitive("asSymbol", _as_symbol))
+        self._install_instance_primitive(UnaryPrimitive("length", _length))
+        self._install_instance_primitive(BinaryPrimitive("=", _equals))
         self._install_instance_primitive(
-            BinaryPrimitive("concatenate:", self.universe, _concat)
+            TernaryPrimitive("primSubstringFrom:to:", _substring)
         )
-        self._install_instance_primitive(
-            UnaryPrimitive("asSymbol", self.universe, _as_symbol)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("length", self.universe, _length)
-        )
-        self._install_instance_primitive(BinaryPrimitive("=", self.universe, _equals))
-        self._install_instance_primitive(
-            TernaryPrimitive("primSubstringFrom:to:", self.universe, _substring)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("hashcode", self.universe, _hashcode)
-        )
+        self._install_instance_primitive(UnaryPrimitive("hashcode", _hashcode))
 
-        self._install_instance_primitive(
-            UnaryPrimitive("isWhiteSpace", self.universe, _is_whitespace)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("isLetters", self.universe, _is_letters)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("isDigits", self.universe, _is_digits)
-        )
+        self._install_instance_primitive(UnaryPrimitive("isWhiteSpace", _is_whitespace))
+        self._install_instance_primitive(UnaryPrimitive("isLetters", _is_letters))
+        self._install_instance_primitive(UnaryPrimitive("isDigits", _is_digits))

--- a/src/som/primitives/symbol_primitives.py
+++ b/src/som/primitives/symbol_primitives.py
@@ -16,9 +16,5 @@ def _equals(op1, op2):
 
 class SymbolPrimitivesBase(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(
-            UnaryPrimitive("asString", self.universe, _as_string)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("=", self.universe, _equals), False
-        )
+        self._install_instance_primitive(UnaryPrimitive("asString", _as_string))
+        self._install_instance_primitive(BinaryPrimitive("=", _equals), False)

--- a/src/som/primitives/system_primitives.py
+++ b/src/som/primitives/system_primitives.py
@@ -93,36 +93,20 @@ def _full_gc(_rcvr):
 
 class SystemPrimitivesBase(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(BinaryPrimitive("load:", self.universe, _load))
-        self._install_instance_primitive(BinaryPrimitive("exit:", self.universe, _exit))
+        self._install_instance_primitive(BinaryPrimitive("load:", _load))
+        self._install_instance_primitive(BinaryPrimitive("exit:", _exit))
+        self._install_instance_primitive(BinaryPrimitive("hasGlobal:", _has_global))
+        self._install_instance_primitive(BinaryPrimitive("global:", _global))
+        self._install_instance_primitive(TernaryPrimitive("global:put:", _global_put))
+        self._install_instance_primitive(BinaryPrimitive("printString:", _print_string))
+        self._install_instance_primitive(UnaryPrimitive("printNewline", _print_newline))
+        self._install_instance_primitive(BinaryPrimitive("errorPrint:", _error_print))
         self._install_instance_primitive(
-            BinaryPrimitive("hasGlobal:", self.universe, _has_global)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("global:", self.universe, _global)
-        )
-        self._install_instance_primitive(
-            TernaryPrimitive("global:put:", self.universe, _global_put)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("printString:", self.universe, _print_string)
-        )
-        self._install_instance_primitive(
-            UnaryPrimitive("printNewline", self.universe, _print_newline)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("errorPrint:", self.universe, _error_print)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("errorPrintln:", self.universe, _error_println)
+            BinaryPrimitive("errorPrintln:", _error_println)
         )
 
-        self._install_instance_primitive(UnaryPrimitive("time", self.universe, _time))
-        self._install_instance_primitive(UnaryPrimitive("ticks", self.universe, _ticks))
-        self._install_instance_primitive(
-            UnaryPrimitive("fullGC", self.universe, _full_gc)
-        )
+        self._install_instance_primitive(UnaryPrimitive("time", _time))
+        self._install_instance_primitive(UnaryPrimitive("ticks", _ticks))
+        self._install_instance_primitive(UnaryPrimitive("fullGC", _full_gc))
 
-        self._install_instance_primitive(
-            BinaryPrimitive("loadFile:", self.universe, _load_file)
-        )
+        self._install_instance_primitive(BinaryPrimitive("loadFile:", _load_file))

--- a/src/som/primitives/true_primitives.py
+++ b/src/som/primitives/true_primitives.py
@@ -37,23 +37,15 @@ def _if_true_if_false(_rcvr, true_block, _false_block):
 
 class TruePrimitivesBase(Primitives):
     def install_primitives(self):
-        self._install_instance_primitive(UnaryPrimitive("not", self.universe, _not))
-        self._install_instance_primitive(BinaryPrimitive("or:", self.universe, _or))
-        self._install_instance_primitive(BinaryPrimitive("||", self.universe, _or))
+        self._install_instance_primitive(UnaryPrimitive("not", _not))
+        self._install_instance_primitive(BinaryPrimitive("or:", _or))
+        self._install_instance_primitive(BinaryPrimitive("||", _or))
+
+        self._install_instance_primitive(BinaryPrimitive("and:", _and_and_if_true))
+        self._install_instance_primitive(BinaryPrimitive("&&", _and_and_if_true))
+        self._install_instance_primitive(BinaryPrimitive("ifTrue:", _and_and_if_true))
+        self._install_instance_primitive(BinaryPrimitive("ifFalse:", _if_false))
 
         self._install_instance_primitive(
-            BinaryPrimitive("and:", self.universe, _and_and_if_true)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("&&", self.universe, _and_and_if_true)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("ifTrue:", self.universe, _and_and_if_true)
-        )
-        self._install_instance_primitive(
-            BinaryPrimitive("ifFalse:", self.universe, _if_false)
-        )
-
-        self._install_instance_primitive(
-            TernaryPrimitive("ifTrue:ifFalse:", self.universe, _if_true_if_false)
+            TernaryPrimitive("ifTrue:ifFalse:", _if_true_if_false)
         )

--- a/src/som/vm/shell.py
+++ b/src/som/vm/shell.py
@@ -1,6 +1,7 @@
 from rlib.objectmodel import we_are_translated
 from rlib.osext import raw_input
 from som.vm.globals import nilObject
+from som.vm.symbols import symbol_for
 
 
 class Shell(object):
@@ -40,9 +41,7 @@ class Shell(object):
                 # If success
                 if shell_class:
                     shell_object = self.universe.new_instance(shell_class)
-                    shell_method = shell_class.lookup_invokable(
-                        self.universe.symbol_for("run:")
-                    )
+                    shell_method = shell_class.lookup_invokable(symbol_for("run:"))
 
                     it = shell_method.invoke_2(shell_object, it)
             except Exception as ex:  # pylint: disable=broad-except

--- a/src/som/vm/symbols.py
+++ b/src/som/vm/symbols.py
@@ -1,0 +1,31 @@
+# pylint: disable=invalid-name
+from rlib.jit import elidable
+from som.vmobjects.symbol import Symbol
+
+_symbol_table = {}
+
+
+@elidable
+def symbol_for(string):
+    # Lookup the symbol in the symbol table
+    result = _symbol_table.get(string, None)
+    if result is not None:
+        return result
+
+    result = Symbol(string)
+    # Insert the new symbol into the symbol table
+    _symbol_table[string] = result
+    return result
+
+
+sym_array = symbol_for("Array")
+sym_object = symbol_for("Object")
+sym_nil = symbol_for("nil")
+sym_true = symbol_for("true")
+sym_false = symbol_for("false")
+sym_plus = symbol_for("+")
+sym_minus = symbol_for("-")
+sym_array_size_placeholder = symbol_for("ArraySizeLiteralPlaceholder")
+
+sym_new_msg = symbol_for("new:")
+sym_at_put_msg = symbol_for("at:put:")

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -99,6 +99,8 @@ class Universe(object):
         self.double_layout = None
 
         self.sym_nil = self.symbol_for("nil")
+        self.sym_true = self.symbol_for("true")
+        self.sym_false = self.symbol_for("false")
         self.sym_plus = self.symbol_for("+")
         self.sym_minus = self.symbol_for("-")
 
@@ -304,8 +306,8 @@ class Universe(object):
 
         # Put special objects and classes into the dictionary of globals
         self.set_global(self.sym_nil, nilObject)
-        self.set_global(self.symbol_for("true"), trueObject)
-        self.set_global(self.symbol_for("false"), falseObject)
+        self.set_global(self.sym_true, trueObject)
+        self.set_global(self.sym_false, falseObject)
         self.set_global(self.symbol_for("system"), system_object)
         self.set_global(self.symbol_for("System"), self.system_class)
         self.set_global(self.symbol_for("Block"), self.block_class)

--- a/src/som/vmobjects/block_bc.py
+++ b/src/som/vmobjects/block_bc.py
@@ -57,13 +57,13 @@ class BcBlock(AbstractObject):
         return universe.block_layouts[self._method.get_number_of_arguments()]
 
 
-def block_evaluation_primitive(num_args, universe):
+def block_evaluation_primitive(num_args):
     if num_args == 1:
-        return UnaryPrimitive(VALUE_SIGNATURE[num_args], universe, _invoke_1)
+        return UnaryPrimitive(VALUE_SIGNATURE[num_args], _invoke_1)
     if num_args == 2:
-        return BinaryPrimitive(VALUE_SIGNATURE[num_args], universe, _invoke_2)
+        return BinaryPrimitive(VALUE_SIGNATURE[num_args], _invoke_2)
     if num_args == 3:
-        return TernaryPrimitive(VALUE_SIGNATURE[num_args], universe, _invoke_3)
+        return TernaryPrimitive(VALUE_SIGNATURE[num_args], _invoke_3)
     raise Exception("Unsupported number of arguments for block: " + str(num_args))
 
 

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -15,6 +15,7 @@ from som.compiler.bc.bytecode_generator import (
     emit_push_field_with_index,
     emit_pop_field_with_index,
     emit3_with_dummy,
+    compute_offset,
 )
 from som.interpreter.ast.frame import (
     get_inner_as_context,
@@ -395,10 +396,17 @@ class BcMethod(BcAbstractMethod):
             ):
                 # emit the jump, but instead of the offset, emit a dummy
                 idx = emit3_with_dummy(mgenc, bytecode)
-
-                offset1 = self.get_bytecode(i + 1)
-                offset2 = self.get_bytecode(i + 2)
-                heappush(jumps, _Jump(i + (offset1 + (offset2 << 8)), bytecode, idx))
+                heappush(
+                    jumps,
+                    _Jump(
+                        i
+                        + compute_offset(
+                            self.get_bytecode(i + 1), self.get_bytecode(i + 2)
+                        ),
+                        bytecode,
+                        idx,
+                    ),
+                )
 
             elif (
                 bytecode == Bytecodes.jump_backward

--- a/src/som/vmobjects/primitive.py
+++ b/src/som/vmobjects/primitive.py
@@ -1,14 +1,15 @@
 from som.interp_type import is_ast_interpreter
+from som.vm.symbols import symbol_for
 from som.vmobjects.abstract_object import AbstractObject
 
 
 class _AbstractPrimitive(AbstractObject):
     _immutable_fields_ = ["_is_empty", "_signature", "_holder"]
 
-    def __init__(self, signature_string, universe, is_empty=False):
+    def __init__(self, signature_string, is_empty=False):
         AbstractObject.__init__(self)
 
-        self._signature = universe.symbol_for(signature_string)
+        self._signature = symbol_for(signature_string)
         self._is_empty = is_empty
         self._holder = None
 
@@ -51,8 +52,8 @@ class _AbstractPrimitive(AbstractObject):
 class _AstPrimitive(_AbstractPrimitive):
     _immutable_fields_ = ["_prim_fn"]
 
-    def __init__(self, signature_string, universe, prim_fn, is_empty=False):
-        _AbstractPrimitive.__init__(self, signature_string, universe, is_empty)
+    def __init__(self, signature_string, prim_fn, is_empty=False):
+        _AbstractPrimitive.__init__(self, signature_string, is_empty)
         self._prim_fn = prim_fn
 
     def invoke_args(self, rcvr, args):
@@ -63,8 +64,8 @@ class _AstPrimitive(_AbstractPrimitive):
 class _BcPrimitive(_AbstractPrimitive):
     _immutable_fields_ = ["_prim_fn"]
 
-    def __init__(self, signature_string, universe, prim_fn, is_empty=False):
-        _AbstractPrimitive.__init__(self, signature_string, universe, is_empty)
+    def __init__(self, signature_string, prim_fn, is_empty=False):
+        _AbstractPrimitive.__init__(self, signature_string, is_empty)
         self._prim_fn = prim_fn
 
     def invoke_n(self, stack, stack_ptr):
@@ -78,8 +79,8 @@ class _BcPrimitive(_AbstractPrimitive):
 class UnaryPrimitive(_AbstractPrimitive):
     _immutable_fields_ = ["_prim_fn"]
 
-    def __init__(self, signature_string, universe, prim_fn, is_empty=False):
-        _AbstractPrimitive.__init__(self, signature_string, universe, is_empty)
+    def __init__(self, signature_string, prim_fn, is_empty=False):
+        _AbstractPrimitive.__init__(self, signature_string, is_empty)
         self._prim_fn = prim_fn
 
     def invoke_1(self, rcvr):
@@ -93,8 +94,8 @@ class UnaryPrimitive(_AbstractPrimitive):
 class BinaryPrimitive(_AbstractPrimitive):
     _immutable_fields_ = ["_prim_fn"]
 
-    def __init__(self, signature_string, universe, prim_fn, is_empty=False):
-        _AbstractPrimitive.__init__(self, signature_string, universe, is_empty)
+    def __init__(self, signature_string, prim_fn, is_empty=False):
+        _AbstractPrimitive.__init__(self, signature_string, is_empty)
         self._prim_fn = prim_fn
 
     def invoke_2(self, rcvr, arg):
@@ -108,8 +109,8 @@ class BinaryPrimitive(_AbstractPrimitive):
 class TernaryPrimitive(_AbstractPrimitive):
     _immutable_fields_ = ["_prim_fn"]
 
-    def __init__(self, signature_string, universe, prim_fn, is_empty=False):
-        _AbstractPrimitive.__init__(self, signature_string, universe, is_empty)
+    def __init__(self, signature_string, prim_fn, is_empty=False):
+        _AbstractPrimitive.__init__(self, signature_string, is_empty)
         self._prim_fn = prim_fn
 
     def invoke_3(self, rcvr, arg1, arg2):
@@ -145,6 +146,6 @@ else:
     _empty_invoke = _empty_invoke_bc
 
 
-def empty_primitive(signature_string, universe):
+def empty_primitive(signature_string):
     """Return an empty primitive with the given signature"""
-    return Primitive(signature_string, universe, _empty_invoke, True)
+    return Primitive(signature_string, _empty_invoke, True)

--- a/tests/jit.py
+++ b/tests/jit.py
@@ -8,6 +8,7 @@ from rpython import conftest  # pylint: disable=import-error
 from rpython.jit.metainterp.test.test_ajit import LLJitMixin  # pylint: disable=E
 
 from som.vm.current import current_universe
+from som.vm.symbols import symbol_for
 from som.vm.universe import Exit
 
 from som.compiler.sourcecode_compiler import compile_class_from_string
@@ -34,7 +35,7 @@ class TestLLtype(LLJitMixin):
         universe._initialize_object_system()  # pylint: disable=protected-access
         cls = compile_class_from_string(source, None, universe)
         obj = universe.new_instance(cls)
-        invokable = cls.lookup_invokable(universe.symbol_for(start))
+        invokable = cls.lookup_invokable(symbol_for(start))
         return universe, obj, invokable
 
     def _run_meta_interp(self, program, main_method, classpath=cp):

--- a/tests/test_ast_inlining.py
+++ b/tests/test_ast_inlining.py
@@ -26,6 +26,7 @@ from som.interpreter.ast.nodes.variable_node import (
 )
 from som.vm.current import current_universe
 from som.vm.globals import trueObject, falseObject
+from som.vm.symbols import symbol_for
 
 pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
     is_bytecode_interpreter(), reason="Tests are specific to AST interpreter"
@@ -33,13 +34,13 @@ pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
 
 
 def add_field(cgenc, name):
-    cgenc.add_instance_field(current_universe.symbol_for(name))
+    cgenc.add_instance_field(symbol_for(name))
 
 
 @pytest.fixture
 def cgenc():
     gen_c = ClassGenerationContext(current_universe)
-    gen_c.name = current_universe.symbol_for("Test")
+    gen_c.name = symbol_for("Test")
     return gen_c
 
 

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -10,6 +10,7 @@ from som.compiler.class_generation_context import ClassGenerationContext
 from som.interp_type import is_ast_interpreter
 from som.interpreter.bc.bytecodes import Bytecodes, bytecode_length, bytecode_as_str
 from som.vm.current import current_universe
+from som.vm.symbols import symbol_for
 
 pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
     is_ast_interpreter(), reason="Tests are specific to bytecode interpreter"
@@ -17,7 +18,7 @@ pytestmark = pytest.mark.skipif(  # pylint: disable=invalid-name
 
 
 def add_field(cgenc, name):
-    cgenc.add_instance_field(current_universe.symbol_for(name))
+    cgenc.add_instance_field(symbol_for(name))
 
 
 def dump(mgenc):
@@ -27,7 +28,7 @@ def dump(mgenc):
 @pytest.fixture
 def cgenc():
     gen_c = ClassGenerationContext(current_universe)
-    gen_c.name = current_universe.symbol_for("Test")
+    gen_c.name = symbol_for("Test")
     return gen_c
 
 
@@ -40,7 +41,7 @@ def mgenc(cgenc):
 
 @pytest.fixture
 def bgenc(cgenc, mgenc):
-    mgenc.signature = current_universe.symbol_for("test")
+    mgenc.signature = symbol_for("test")
     bgenc = MethodGenerationContext(current_universe, cgenc, mgenc)
     return bgenc
 

--- a/tests/test_optimize_trivial.py
+++ b/tests/test_optimize_trivial.py
@@ -6,6 +6,7 @@ from som.compiler.bc.disassembler import dump_method
 from som.compiler.class_generation_context import ClassGenerationContext
 from som.interp_type import is_ast_interpreter
 from som.vm.current import current_universe
+from som.vm.symbols import symbol_for
 from som.vmobjects.method_ast import AstMethod
 from som.vmobjects.method_bc import BcMethod
 from som.vmobjects.method_trivial import (
@@ -24,7 +25,7 @@ else:
 
 
 def add_field(cgenc, name):
-    cgenc.add_instance_field(current_universe.symbol_for(name))
+    cgenc.add_instance_field(symbol_for(name))
 
 
 def dump(mgenc):
@@ -34,7 +35,7 @@ def dump(mgenc):
 @pytest.fixture
 def cgenc():
     gen_c = ClassGenerationContext(current_universe)
-    gen_c.name = current_universe.symbol_for("Test")
+    gen_c.name = symbol_for("Test")
     return gen_c
 
 
@@ -42,7 +43,7 @@ def cgenc():
 def mgenc(cgenc):
     mgenc = MethodGenerationContext(current_universe, cgenc, None)
     mgenc.add_argument("self", None, None)
-    mgenc.signature = current_universe.symbol_for("test")
+    mgenc.signature = symbol_for("test")
     return mgenc
 
 


### PR DESCRIPTION
Port some maintenance from TruffleSOM to be in sync.
This seems to have a negative impact on interpretation speed, especially for SomSom BC benchmarks.

Though, I don't really know why. The first change, using symbol equality instead of strings for comparison seems to be the main issue, but I can't think of why, and haven't tried to investigate.

Overall, I think these changes are still positive, in avoiding pathological cases (second pass over bytecode), and separating things a little more (extracting the symbol table to its own module).