### PR TITLE
Add AST and BC support for increment operation and field increments

### DIFF
--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -11,6 +11,10 @@ def emit_dec(mgenc):
     emit1(mgenc, BC.dec, 0)
 
 
+def emit_inc_field_push(mgenc, field_idx, ctx_level):
+    emit3(mgenc, BC.inc_field_push, field_idx, ctx_level, 1)
+
+
 def emit_pop(mgenc):
     if not mgenc.optimize_dup_pop_pop_sequence():
         emit1(mgenc, BC.pop, -1)
@@ -94,6 +98,10 @@ def emit_pop_local(mgenc, idx, ctx):
 def emit_pop_field(mgenc, field_name):
     ctx_level = mgenc.get_max_context_level()
     field_idx = mgenc.get_field_index(field_name)
+
+    if mgenc.optimize_inc_field(field_idx, ctx_level):
+        return
+
     emit_pop_field_with_index(mgenc, field_idx, ctx_level)
 
 

--- a/src/som/compiler/bc/disassembler.py
+++ b/src/som/compiler/bc/disassembler.py
@@ -106,7 +106,8 @@ def dump_bytecode(m, b, indent=""):
     elif (
         bytecode == Bytecodes.push_field
         or bytecode == Bytecodes.pop_field
-        or Bytecodes.inc_field_push
+        or bytecode == Bytecodes.inc_field_push
+        or bytecode == Bytecodes.inc_field
     ):
         if m.get_holder():
             field_name = str(

--- a/src/som/compiler/bc/disassembler.py
+++ b/src/som/compiler/bc/disassembler.py
@@ -103,7 +103,11 @@ def dump_bytecode(m, b, indent=""):
     ):
         # don't need any other arguments
         error_println("")
-    elif bytecode == Bytecodes.push_field or bytecode == Bytecodes.pop_field:
+    elif (
+        bytecode == Bytecodes.push_field
+        or bytecode == Bytecodes.pop_field
+        or Bytecodes.inc_field_push
+    ):
         if m.get_holder():
             field_name = str(
                 m.get_holder().get_instance_field_name(m.get_bytecode(b + 1))

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -35,6 +35,7 @@ from som.vmobjects.primitive import empty_primitive
 from som.vmobjects.method_bc import (
     BcMethodNLR,
     BcMethod,
+    BackJump,
 )
 
 _NUM_LAST_BYTECODES = 4
@@ -637,7 +638,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
         backward_jump_idx = self.offset_of_next_instruction()
         emit_jump_backward_with_offset(self, jump_offset)
 
-        self.inlined_loops.append(_Loop(loop_begin_idx, backward_jump_idx))
+        self.inlined_loops.append(BackJump(loop_begin_idx, backward_jump_idx))
 
     def patch_jump_offset_to_point_to_next_instruction(self, idx_of_offset, parser):
         instruction_start = idx_of_offset - 1
@@ -676,14 +677,6 @@ class MethodGenerationContext(MethodGenerationContextBase):
                 Symbol.NONE,
                 parser,
             )
-
-
-class _Loop(object):
-    _immutable_fields_ = ["loop_begin_idx", "backward_jump_idx"]
-
-    def __init__(self, loop_begin_idx, backward_jump_idx):
-        self.loop_begin_idx = loop_begin_idx
-        self.backward_jump_idx = backward_jump_idx
 
 
 class FindVarResult(object):

--- a/src/som/interpreter/ast/nodes/field_node.py
+++ b/src/som/interpreter/ast/nodes/field_node.py
@@ -1,6 +1,7 @@
 from som.compiler.ast.variable import Argument
 from som.interpreter.ast.nodes.contextual_node import ContextualNode
 from som.interpreter.ast.nodes.expression_node import ExpressionNode
+from som.interpreter.ast.nodes.specialized.int_inc_node import IntIncrementNode
 from som.interpreter.ast.nodes.variable_node import UninitializedReadNode
 from som.vmobjects.method_trivial import FieldRead, FieldWrite
 
@@ -64,9 +65,17 @@ class FieldWriteNode(_AbstractFieldNode):
         return True
 
 
+class FieldIncrementNode(_AbstractFieldNode):
+    def execute(self, frame):
+        self_obj = self._self_exp.execute(frame)
+        return self_obj.inc_field(self.field_idx)
+
+
 def create_read_node(self_exp, index, source_section=None):
     return FieldReadNode(self_exp, index, source_section)
 
 
 def create_write_node(self_exp, value_exp, index, source_section=None):
+    if isinstance(value_exp, IntIncrementNode) and value_exp.does_access_field(index):
+        return FieldIncrementNode(self_exp, index, source_section)
     return FieldWriteNode(self_exp, value_exp, index, source_section)

--- a/src/som/interpreter/ast/nodes/specialized/int_inc_node.py
+++ b/src/som/interpreter/ast/nodes/specialized/int_inc_node.py
@@ -12,3 +12,9 @@ class IntIncrementNode(ExpressionNode):
     def execute(self, frame):
         result = self._rcvr_expr.execute(frame)
         return result.prim_inc()
+
+    def does_access_field(self, field_idx):
+        from som.interpreter.ast.nodes.field_node import FieldReadNode
+
+        rcvr = self._rcvr_expr
+        return isinstance(rcvr, FieldReadNode) and field_idx == rcvr.field_idx

--- a/src/som/interpreter/ast/nodes/specialized/int_inc_node.py
+++ b/src/som/interpreter/ast/nodes/specialized/int_inc_node.py
@@ -1,0 +1,14 @@
+from som.interpreter.ast.nodes.expression_node import ExpressionNode
+
+
+class IntIncrementNode(ExpressionNode):
+    _immutable_fields_ = ["_rcvr_expr?"]
+    _child_nodes_ = ["_rcvr_expr"]
+
+    def __init__(self, rcvr_expr, source_section):
+        ExpressionNode.__init__(self, source_section)
+        self._rcvr_expr = self.adopt_child(rcvr_expr)
+
+    def execute(self, frame):
+        result = self._rcvr_expr.execute(frame)
+        return result.prim_inc()

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -65,7 +65,8 @@ class Bytecodes(object):
     inc = return_self + 1
     dec = inc + 1
 
-    inc_field_push = dec + 1
+    inc_field = dec + 1
+    inc_field_push = inc_field + 1
 
     jump = inc_field_push + 1
     jump_on_true_top_nil = jump + 1
@@ -228,6 +229,7 @@ _BYTECODE_LENGTH = [
     1,  # return_self
     1,  # inc
     1,  # dec
+    3,  # inc_field
     3,  # inc_field_push
     3,  # jump
     3,  # jump_on_true_top_nil
@@ -301,6 +303,7 @@ _BYTECODE_STACK_EFFECT = [
     0,  # return_self
     0,  # inc
     0,  # dec
+    0,  # inc_field
     1,  # inc_field_push
     0,  # jump
     0,  # jump_on_true_top_nil

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -65,7 +65,9 @@ class Bytecodes(object):
     inc = return_self + 1
     dec = inc + 1
 
-    jump = dec + 1
+    inc_field_push = dec + 1
+
+    jump = inc_field_push + 1
     jump_on_true_top_nil = jump + 1
     jump_on_false_top_nil = jump_on_true_top_nil + 1
     jump_on_true_pop = jump_on_false_top_nil + 1
@@ -226,6 +228,7 @@ _BYTECODE_LENGTH = [
     1,  # return_self
     1,  # inc
     1,  # dec
+    3,  # inc_field_push
     3,  # jump
     3,  # jump_on_true_top_nil
     3,  # jump_on_false_top_nil
@@ -298,6 +301,7 @@ _BYTECODE_STACK_EFFECT = [
     0,  # return_self
     0,  # inc
     0,  # dec
+    1,  # inc_field_push
     0,  # jump
     0,  # jump_on_true_top_nil
     0,  # jump_on_false_top_nil

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -6,7 +6,7 @@ from som.interpreter.ast.frame import (
     FRAME_AND_INNER_RCVR_IDX,
     get_inner_as_context,
 )
-from som.interpreter.bc.bytecodes import bytecode_length, Bytecodes
+from som.interpreter.bc.bytecodes import bytecode_length, Bytecodes, bytecode_as_str
 from som.interpreter.bc.frame import (
     get_block_at,
     get_self_dynamically,
@@ -479,6 +479,14 @@ def interpret(method, frame, max_stack_size):
                 return _not_yet_implemented()
             stack[stack_ptr] = result
 
+        elif bytecode == Bytecodes.inc_field_push:
+            field_idx = method.get_bytecode(current_bc_idx + 1)
+            ctx_level = method.get_bytecode(current_bc_idx + 2)
+            self_obj = get_self(frame, ctx_level)
+
+            stack_ptr += 1
+            stack[stack_ptr] = self_obj.inc_field(field_idx)
+
         elif bytecode == Bytecodes.jump:
             next_bc_idx = current_bc_idx + method.get_bytecode(current_bc_idx + 1)
 
@@ -657,7 +665,12 @@ def _unknown_bytecode(bytecode, bytecode_idx, method):
 
     dump_method(method, "")
     raise Exception(
-        "Unknown bytecode: " + str(bytecode) + " at bci: " + str(bytecode_idx)
+        "Unknown bytecode: "
+        + str(bytecode)
+        + " "
+        + bytecode_as_str(bytecode)
+        + " at bci: "
+        + str(bytecode_idx)
     )
 
 
@@ -729,7 +742,6 @@ def _send_does_not_understand(receiver, selector, stack, stack_ptr):
 
 def get_printable_location(bytecode_index, method):
     from som.vmobjects.method_bc import BcAbstractMethod
-    from som.interpreter.bc.bytecodes import bytecode_as_str
 
     assert isinstance(method, BcAbstractMethod)
     bc = method.get_bytecode(bytecode_index)

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -479,6 +479,13 @@ def interpret(method, frame, max_stack_size):
                 return _not_yet_implemented()
             stack[stack_ptr] = result
 
+        elif bytecode == Bytecodes.inc_field:
+            field_idx = method.get_bytecode(current_bc_idx + 1)
+            ctx_level = method.get_bytecode(current_bc_idx + 2)
+            self_obj = get_self(frame, ctx_level)
+
+            self_obj.inc_field(field_idx)
+
         elif bytecode == Bytecodes.inc_field_push:
             field_idx = method.get_bytecode(current_bc_idx + 1)
             ctx_level = method.get_bytecode(current_bc_idx + 2)

--- a/src/som/interpreter/objectstorage/storage_location.py
+++ b/src/som/interpreter/objectstorage/storage_location.py
@@ -1,3 +1,4 @@
+from rlib.arithmetic import ovfcheck
 from rlib.objectmodel import longlong2float, float2longlong
 from som.interpreter.objectstorage.layout_transitions import (
     UninitializedStorageLocationException,
@@ -19,6 +20,7 @@ class _Location(object):
         "mask",
         "is_set_fn",
         "read_fn",
+        "inc_fn",
         "write_fn",
         "store_idx",
         "storage_type",
@@ -31,6 +33,7 @@ class _Location(object):
         access_idx,
         is_set_fn,
         read_fn,
+        inc_fn,
         write_fn,
         storage_type,
     ):
@@ -39,6 +42,7 @@ class _Location(object):
         self.mask = _get_primitive_field_mask(store_idx)
         self.is_set_fn = is_set_fn
         self.read_fn = read_fn
+        self.inc_fn = inc_fn
         self.write_fn = write_fn
         self.store_idx = store_idx
         self.storage_type = storage_type
@@ -63,6 +67,7 @@ def create_location_for_long(field_idx, prim_field_idx):
             -1,
             _prim_is_set,
             _long_direct_read[prim_field_idx],
+            _long_direct_inc[prim_field_idx],
             _long_direct_write[prim_field_idx],
             Integer,
         )
@@ -72,6 +77,7 @@ def create_location_for_long(field_idx, prim_field_idx):
         prim_field_idx - NUMBER_OF_PRIMITIVE_FIELDS,
         _prim_is_set,
         _long_array_read,
+        _long_array_inc,
         _long_array_write,
         Integer,
     )
@@ -85,6 +91,7 @@ def create_location_for_double(field_idx, prim_field_idx):
             -1,
             _prim_is_set,
             _double_direct_read[prim_field_idx],
+            _double_direct_inc[prim_field_idx],
             _double_direct_write[prim_field_idx],
             Double,
         )
@@ -94,6 +101,7 @@ def create_location_for_double(field_idx, prim_field_idx):
         prim_field_idx - NUMBER_OF_PRIMITIVE_FIELDS,
         _prim_is_set,
         _double_array_read,
+        _double_array_inc,
         _double_array_write,
         Double,
     )
@@ -109,6 +117,7 @@ def create_location_for_object(field_idx, ptr_field_idx):
             -1,
             _object_is_set,
             _object_direct_read[ptr_field_idx],
+            _object_direct_inc[ptr_field_idx],
             _object_direct_write[ptr_field_idx],
             Object,
         )
@@ -118,6 +127,7 @@ def create_location_for_object(field_idx, ptr_field_idx):
         ptr_field_idx - NUMBER_OF_POINTER_FIELDS,
         _object_is_set,
         _object_array_read,
+        _object_array_inc,
         _object_array_write,
         Object,
     )
@@ -125,7 +135,14 @@ def create_location_for_object(field_idx, ptr_field_idx):
 
 def create_location_for_unwritten(field_idx):
     return _Location(
-        field_idx, -1, -1, _unwritten_is_set, _unwritten_read, _unwritten_write, None
+        field_idx,
+        -1,
+        -1,
+        _unwritten_is_set,
+        _unwritten_read,
+        _unwritten_inc,
+        _unwritten_write,
+        None,
     )
 
 
@@ -135,6 +152,10 @@ def _unwritten_is_set(_node, _obj):
 
 def _unwritten_read(_node, _obj):
     return nilObject
+
+
+def _unwritten_inc(_node, _obj):
+    raise UninitializedStorageLocationException()
 
 
 def _unwritten_write(_node, _obj, value):
@@ -147,6 +168,17 @@ def _make_object_direct_read(field_idx):
         return getattr(obj, "_field" + str(field_idx))
 
     return read_location
+
+
+def _make_object_direct_inc(field_idx):
+    def inc_location(_node, obj):
+        field_name = "_field" + str(field_idx)
+        val = getattr(obj, field_name)
+        new_val = val.prim_inc()
+        setattr(obj, field_name, new_val)
+        return new_val
+
+    return inc_location
 
 
 def _make_object_direct_write(field_idx):
@@ -162,6 +194,13 @@ def _object_is_set(_node, _obj):
 
 def _object_array_read(node, obj):
     return obj.fields[node.access_idx]
+
+
+def _object_array_inc(node, obj):
+    val = obj.fields[node.access_idx]
+    new_val = val.prim_inc()
+    obj.fields[node.access_idx] = new_val
+    return new_val
 
 
 def _object_array_write(node, obj, value):
@@ -189,6 +228,19 @@ def _make_double_direct_read(field_idx):
     return read_location
 
 
+def _make_double_direct_inc(field_idx):
+    def inc_location(node, obj):
+        if obj.is_primitive_set(node.mask):
+            field_name = "prim_field" + str(field_idx)
+            double_val = longlong2float(getattr(obj, field_name))
+            double_val += 1.0
+            setattr(obj, field_name, float2longlong(double_val))
+            return Double(double_val)
+        raise NotImplementedError()
+
+    return inc_location
+
+
 def _make_double_direct_write(field_idx):
     def write_location(node, obj, value):
         if isinstance(value, Double):
@@ -213,6 +265,22 @@ def _make_long_direct_read(field_idx):
     return read_location
 
 
+def _make_long_direct_inc(field_idx):
+    def read_location(node, obj):
+        if obj.is_primitive_set(node.mask):
+            field_name = "prim_field" + str(field_idx)
+            val = getattr(obj, field_name)
+            try:
+                result = ovfcheck(val + 1)
+                setattr(obj, field_name, result)
+                return Integer(result)
+            except OverflowError:
+                raise NotImplementedError()
+        raise NotImplementedError()
+
+    return read_location
+
+
 def _make_long_direct_write(field_idx):
     def write_location(node, obj, value):
         if isinstance(value, Integer):
@@ -230,6 +298,18 @@ def _long_array_read(node, obj):
     return nilObject
 
 
+def _long_array_inc(node, obj):
+    if obj.is_primitive_set(node.mask):
+        val = obj.prim_fields[node.access_idx]
+        try:
+            result = ovfcheck(val + 1)
+            obj.prim_fields[node.access_idx] = result
+            return Integer(result)
+        except OverflowError:
+            raise NotImplementedError()
+    raise NotImplementedError()
+
+
 def _long_array_write(node, obj, value):
     if isinstance(value, Integer):
         obj.prim_fields[node.access_idx] = value.get_embedded_integer()
@@ -245,6 +325,15 @@ def _double_array_read(node, obj):
     return nilObject
 
 
+def _double_array_inc(node, obj):
+    if obj.is_primitive_set(node.mask):
+        val = longlong2float(obj.prim_fields[node.access_idx])
+        val += 1.0
+        obj.prim_fields[node.access_idx] = float2longlong(val)
+        return Double(val)
+    raise NotImplementedError()
+
+
 def _double_array_write(node, obj, value):
     if isinstance(value, Double):
         val = float2longlong(value.get_embedded_double())
@@ -257,6 +346,9 @@ def _double_array_write(node, obj, value):
 _object_direct_read = [
     _make_object_direct_read(i + 1) for i in range(NUMBER_OF_POINTER_FIELDS)
 ]
+_object_direct_inc = [
+    _make_object_direct_inc(i + 1) for i in range(NUMBER_OF_POINTER_FIELDS)
+]
 _object_direct_write = [
     _make_object_direct_write(i + 1) for i in range(NUMBER_OF_POINTER_FIELDS)
 ]
@@ -264,12 +356,18 @@ _object_direct_write = [
 _long_direct_read = [
     _make_long_direct_read(i + 1) for i in range(NUMBER_OF_PRIMITIVE_FIELDS)
 ]
+_long_direct_inc = [
+    _make_long_direct_inc(i + 1) for i in range(NUMBER_OF_PRIMITIVE_FIELDS)
+]
 _long_direct_write = [
     _make_long_direct_write(i + 1) for i in range(NUMBER_OF_PRIMITIVE_FIELDS)
 ]
 
 _double_direct_read = [
     _make_double_direct_read(i + 1) for i in range(NUMBER_OF_PRIMITIVE_FIELDS)
+]
+_double_direct_inc = [
+    _make_double_direct_inc(i + 1) for i in range(NUMBER_OF_PRIMITIVE_FIELDS)
 ]
 _double_direct_write = [
     _make_double_direct_write(i + 1) for i in range(NUMBER_OF_PRIMITIVE_FIELDS)

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -322,7 +322,9 @@ class BcMethod(BcAbstractMethod):
                         ctx_level - 1,
                         1 if Bytecodes.push_argument else -1,
                     )
-            elif bytecode == Bytecodes.inc_field_push:
+            elif (
+                bytecode == Bytecodes.inc_field or bytecode == Bytecodes.inc_field_push
+            ):
                 idx = self.get_bytecode(i + 1)
                 ctx_level = self.get_bytecode(i + 2)
                 assert ctx_level > 0
@@ -526,6 +528,7 @@ class BcMethod(BcAbstractMethod):
                 or bytecode == Bytecodes.push_argument
                 or bytecode == Bytecodes.pop_argument
                 or bytecode == Bytecodes.inc_field_push
+                or bytecode == Bytecodes.inc_field
             ):
                 ctx_level = self.get_bytecode(i + 2)
                 if ctx_level > removed_ctx_level:

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -322,6 +322,11 @@ class BcMethod(BcAbstractMethod):
                         ctx_level - 1,
                         1 if Bytecodes.push_argument else -1,
                     )
+            elif bytecode == Bytecodes.inc_field_push:
+                idx = self.get_bytecode(i + 1)
+                ctx_level = self.get_bytecode(i + 2)
+                assert ctx_level > 0
+                emit3(mgenc, bytecode, idx, ctx_level - 1, 1)
 
             elif bytecode == Bytecodes.push_local or bytecode == Bytecodes.pop_local:
                 idx = self.get_bytecode(i + 1)
@@ -520,6 +525,7 @@ class BcMethod(BcAbstractMethod):
                 or bytecode == Bytecodes.pop_field
                 or bytecode == Bytecodes.push_argument
                 or bytecode == Bytecodes.pop_argument
+                or bytecode == Bytecodes.inc_field_push
             ):
                 ctx_level = self.get_bytecode(i + 2)
                 if ctx_level > removed_ctx_level:

--- a/src/som/vmobjects/object_with_layout.py
+++ b/src/som/vmobjects/object_with_layout.py
@@ -174,6 +174,10 @@ class Object(ObjectWithoutFields):
         location = self.get_location(field_idx)
         return location.read_fn(location, self)
 
+    def inc_field(self, field_idx):
+        location = self.get_location(field_idx)
+        return location.inc_fn(location, self)
+
     def set_field(self, field_idx, value):
         # Set the field with the given index to the given value
         assert isinstance(field_idx, int)

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -1193,10 +1193,11 @@ def test_inc_field(cgenc, mgenc, field_num):
     bytecodes = method_to_bytecodes(
         mgenc, "test = ( " + field_name + " := " + field_name + " + 1 )"
     )
+
     check(
         bytecodes,
         [
-            BC(Bytecodes.inc_field_push, field_num, 0),
+            BC(Bytecodes.inc_field, field_num, 0),
             Bytecodes.return_self,
         ],
     )
@@ -1221,8 +1222,7 @@ def test_inc_field_non_trivial(cgenc, mgenc, field_num):
         [
             Bytecodes.push_1,
             Bytecodes.pop,
-            BC(Bytecodes.inc_field_push, field_num, 0),
-            Bytecodes.pop,
+            BC(Bytecodes.inc_field, field_num, 0),
             Bytecodes.push_constant_1,
             Bytecodes.return_self,
         ],
@@ -1249,6 +1249,32 @@ def test_return_inc_field(cgenc, mgenc, field_num):
             Bytecodes.push_constant_0,
             Bytecodes.pop,
             BC(Bytecodes.inc_field_push, field_num, 0),
+            Bytecodes.return_local,
+        ],
+    )
+
+
+@pytest.mark.parametrize("field_num", range(0, 7))
+def test_return_inc_field_from_block(cgenc, bgenc, field_num):
+    add_field(cgenc, "field0")
+    add_field(cgenc, "field1")
+    add_field(cgenc, "field2")
+    add_field(cgenc, "field3")
+    add_field(cgenc, "field4")
+    add_field(cgenc, "field5")
+    add_field(cgenc, "field6")
+
+    field_name = "field" + str(field_num)
+    bytecodes = block_to_bytecodes(
+        bgenc, "[ #foo. " + field_name + " := " + field_name + " + 1 ]"
+    )
+
+    check(
+        bytecodes,
+        [
+            Bytecodes.push_constant_0,
+            Bytecodes.pop,
+            BC(Bytecodes.inc_field_push, field_num, 1),
             Bytecodes.return_local,
         ],
     )

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -426,16 +426,13 @@ def test_if_true_and_inc_field(cgenc, mgenc):
         )""",
     )
 
-    assert len(bytecodes) == 19
+    assert len(bytecodes) == 18
     check(
         bytecodes,
         [
             (6, Bytecodes.send_2),
-            BC(Bytecodes.jump_on_false_top_nil, 7, note="jump offset"),
-            Bytecodes.push_field_0,
-            Bytecodes.inc,
-            Bytecodes.dup,
-            Bytecodes.pop_field_0,
+            BC(Bytecodes.jump_on_false_top_nil, 6, note="jump offset"),
+            Bytecodes.inc_field_push,
             Bytecodes.pop,
             Bytecodes.push_constant,
         ],
@@ -1178,5 +1175,80 @@ def test_trivial_method_inlining(mgenc, source, bytecode):
             Bytecodes.jump_on_false_top_nil,
             bytecode,
             Bytecodes.return_self,
+        ],
+    )
+
+
+@pytest.mark.parametrize("field_num", range(0, 7))
+def test_inc_field(cgenc, mgenc, field_num):
+    add_field(cgenc, "field0")
+    add_field(cgenc, "field1")
+    add_field(cgenc, "field2")
+    add_field(cgenc, "field3")
+    add_field(cgenc, "field4")
+    add_field(cgenc, "field5")
+    add_field(cgenc, "field6")
+
+    field_name = "field" + str(field_num)
+    bytecodes = method_to_bytecodes(
+        mgenc, "test = ( " + field_name + " := " + field_name + " + 1 )"
+    )
+    check(
+        bytecodes,
+        [
+            BC(Bytecodes.inc_field_push, field_num, 0),
+            Bytecodes.return_self,
+        ],
+    )
+
+
+@pytest.mark.parametrize("field_num", range(0, 7))
+def test_inc_field_non_trivial(cgenc, mgenc, field_num):
+    add_field(cgenc, "field0")
+    add_field(cgenc, "field1")
+    add_field(cgenc, "field2")
+    add_field(cgenc, "field3")
+    add_field(cgenc, "field4")
+    add_field(cgenc, "field5")
+    add_field(cgenc, "field6")
+
+    field_name = "field" + str(field_num)
+    bytecodes = method_to_bytecodes(
+        mgenc, "test = ( 1. " + field_name + " := " + field_name + " + 1. 2 )"
+    )
+    check(
+        bytecodes,
+        [
+            Bytecodes.push_1,
+            Bytecodes.pop,
+            BC(Bytecodes.inc_field_push, field_num, 0),
+            Bytecodes.pop,
+            Bytecodes.push_constant_1,
+            Bytecodes.return_self,
+        ],
+    )
+
+
+@pytest.mark.parametrize("field_num", range(0, 7))
+def test_return_inc_field(cgenc, mgenc, field_num):
+    add_field(cgenc, "field0")
+    add_field(cgenc, "field1")
+    add_field(cgenc, "field2")
+    add_field(cgenc, "field3")
+    add_field(cgenc, "field4")
+    add_field(cgenc, "field5")
+    add_field(cgenc, "field6")
+
+    field_name = "field" + str(field_num)
+    bytecodes = method_to_bytecodes(
+        mgenc, "test = ( #foo. ^ " + field_name + " := " + field_name + " + 1 )"
+    )
+    check(
+        bytecodes,
+        [
+            Bytecodes.push_constant_0,
+            Bytecodes.pop,
+            BC(Bytecodes.inc_field_push, field_num, 0),
+            Bytecodes.return_local,
         ],
     )


### PR DESCRIPTION
In the AST interpreter, this as:
- an `IntIncrementNode`
- a `FieldIncrementNode`

For the BC interpreter, it adds `INC_FIELD` and `INC_FIELD_PUSH`.

Overall this gives a small speedup, but larger improvements on some microbenchmarks for loops, especially the FieldLoop benchmarks. The steady performance is not really influenced.
 
The SomSom benchmarks show only minimal changes. For the AST interpreter, there might be a small overhead of 1-2% more run time. The BC interpreter sees possibly a 2-3% reduction of run time.

https://rebench.stefan-marr.de/compare/RPySOM/aa0b58fcc23afe9235a8ab3713f2de82705dee36/1f478ed207115b4693b661acef81b86d47064226#micro-steady-RPySOM-bc-jit 