### PR TITLE
Implement RETURN_FIELD_0,1,2 bytecodes

### DIFF
--- a/src/som/compiler/bc/bytecode_generator.py
+++ b/src/som/compiler/bc/bytecode_generator.py
@@ -30,11 +30,27 @@ def emit_return_self(mgenc):
 
 
 def emit_return_local(mgenc):
-    emit1(mgenc, BC.return_local, 0)
+    if not mgenc.optimize_return_field():
+        emit1(mgenc, BC.return_local, 0)
 
 
 def emit_return_non_local(mgenc):
     emit2(mgenc, BC.return_non_local, mgenc.get_max_context_level(), 0)
+
+
+def emit_return_field(mgenc, field_idx):
+    if field_idx == 0:
+        emit1(mgenc, BC.return_field_0, 0)
+        return
+    if field_idx == 1:
+        emit1(mgenc, BC.return_field_1, 0)
+        return
+    if field_idx == 2:
+        emit1(mgenc, BC.return_field_2, 0)
+        return
+    raise NotImplementedError(
+        "Don't support fields with index > 2, but got " + str(field_idx)
+    )
 
 
 def emit_dup(mgenc):

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -62,7 +62,11 @@ class Bytecodes(object):
     return_non_local = return_local + 1
     return_self = return_non_local + 1
 
-    inc = return_self + 1
+    return_field_0 = return_self + 1
+    return_field_1 = return_field_0 + 1
+    return_field_2 = return_field_1 + 1
+
+    inc = return_field_2 + 1
     dec = inc + 1
 
     inc_field = dec + 1
@@ -135,6 +139,12 @@ POP_FIELD_BYTECODES = [
     Bytecodes.pop_field_1,
 ]
 
+RETURN_FIELD_BYTECODES = [
+    Bytecodes.return_field_0,
+    Bytecodes.return_field_1,
+    Bytecodes.return_field_2,
+]
+
 JUMP_BYTECODES = [
     Bytecodes.jump,
     Bytecodes.jump_on_true_top_nil,
@@ -181,6 +191,9 @@ NOT_EXPECTED_IN_BLOCK_BYTECODES = [
     Bytecodes.pop_field_0,
     Bytecodes.pop_field_1,
     Bytecodes.return_self,
+    Bytecodes.return_field_0,
+    Bytecodes.return_field_1,
+    Bytecodes.return_field_2,
 ]
 
 _BYTECODE_LENGTH = [
@@ -227,6 +240,9 @@ _BYTECODE_LENGTH = [
     1,  # return_local
     2,  # return_non_local
     1,  # return_self
+    1,  # return_field_0
+    1,  # return_field_1
+    1,  # return_field_2
     1,  # inc
     1,  # dec
     3,  # inc_field
@@ -301,6 +317,9 @@ _BYTECODE_STACK_EFFECT = [
     0,  # return_local
     0,  # return_non_local
     0,  # return_self
+    0,  # return_field_0
+    0,  # return_field_1
+    0,  # return_field_2
     0,  # inc
     0,  # dec
     0,  # inc_field

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -447,6 +447,18 @@ def interpret(method, frame, max_stack_size):
         elif bytecode == Bytecodes.return_self:
             return read_frame(frame, FRAME_AND_INNER_RCVR_IDX)
 
+        elif bytecode == Bytecodes.return_field_0:
+            self_obj = read_frame(frame, FRAME_AND_INNER_RCVR_IDX)
+            return self_obj.get_field(0)
+
+        elif bytecode == Bytecodes.return_field_1:
+            self_obj = read_frame(frame, FRAME_AND_INNER_RCVR_IDX)
+            return self_obj.get_field(1)
+
+        elif bytecode == Bytecodes.return_field_2:
+            self_obj = read_frame(frame, FRAME_AND_INNER_RCVR_IDX)
+            return self_obj.get_field(2)
+
         elif bytecode == Bytecodes.inc:
             val = stack[stack_ptr]
             from som.vmobjects.integer import Integer

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -416,6 +416,13 @@ class BcMethod(BcAbstractMethod):
                     emit_return_non_local(mgenc)
 
             elif (
+                bytecode == Bytecodes.return_field_0
+                or bytecode == Bytecodes.return_field_1
+                or bytecode == Bytecodes.return_field_2
+            ):
+                emit1(mgenc, bytecode, 0)
+
+            elif (
                 bytecode == Bytecodes.jump
                 or bytecode == Bytecodes.jump_on_true_top_nil
                 or bytecode == Bytecodes.jump_on_false_top_nil
@@ -504,6 +511,9 @@ class BcMethod(BcAbstractMethod):
                 or bytecode == Bytecodes.send_n
                 or bytecode == Bytecodes.super_send
                 or bytecode == Bytecodes.return_local
+                or bytecode == Bytecodes.return_field_0
+                or bytecode == Bytecodes.return_field_1
+                or bytecode == Bytecodes.return_field_2
                 or bytecode == Bytecodes.inc
                 or bytecode == Bytecodes.dec
                 or bytecode == Bytecodes.jump

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -1278,3 +1278,35 @@ def test_return_inc_field_from_block(cgenc, bgenc, field_num):
             Bytecodes.return_local,
         ],
     )
+
+
+@pytest.mark.parametrize(
+    "field_num,bytecode",
+    [
+        (0, Bytecodes.return_field_0),
+        (1, Bytecodes.return_field_1),
+        (2, Bytecodes.return_field_2),
+        (3, BC(Bytecodes.push_field, 3)),
+        (4, BC(Bytecodes.push_field, 4)),
+    ],
+)
+def test_return_field(cgenc, mgenc, field_num, bytecode):
+    add_field(cgenc, "field0")
+    add_field(cgenc, "field1")
+    add_field(cgenc, "field2")
+    add_field(cgenc, "field3")
+    add_field(cgenc, "field4")
+    add_field(cgenc, "field5")
+    add_field(cgenc, "field6")
+
+    field_name = "field" + str(field_num)
+    bytecodes = method_to_bytecodes(mgenc, "test = ( 1. ^ " + field_name + " )")
+
+    check(
+        bytecodes,
+        [
+            Bytecodes.push_1,
+            Bytecodes.pop,
+            bytecode,
+        ],
+    )


### PR DESCRIPTION
This syncs PySOM with TruffleSOM, where we have these bytecodes already.
There might be a slight overhead. At least the SomSom BC benchmarks show up to 4% more run time.
Though, I'll keep them for the moment...