### PR TITLE
Inlining #and:/#&&/#or:/#|| and primitive for #downTo:do:

### DIFF
--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -26,6 +26,7 @@ from som.interpreter.bc.bytecodes import (
     FIRST_DOUBLE_BYTE_JUMP_BYTECODE,
     RETURN_FIELD_BYTECODES,
 )
+from som.vm.globals import trueObject, falseObject
 from som.vm.symbols import sym_nil, sym_false, sym_true
 from som.vmobjects.integer import int_0, int_1
 from som.vmobjects.method_trivial import (
@@ -497,7 +498,6 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
         if len(self._literals) == 1:
             from som.vmobjects.symbol import Symbol
-            from som.vm.globals import trueObject, falseObject
 
             global_name = self._literals[0]
             assert isinstance(global_name, Symbol)
@@ -710,6 +710,45 @@ class MethodGenerationContext(MethodGenerationContextBase):
         )
 
         self._is_currently_inlining_a_block = False
+
+        return True
+
+    def inline_andor(self, parser, is_or):
+        # HACK: We do assume that the receiver on the stack is a boolean,
+        # HACK: similar to the IfTrueIfFalseNode.
+        # HACK: We don't support anything but booleans at the moment.
+        push_block_candidate = self._last_bytecode_is_one_of(0, PUSH_BLOCK_BYTECODES)
+        if push_block_candidate == Bytecodes.invalid:
+            return False
+
+        assert bytecode_length(push_block_candidate) == 2
+        block_literal_idx = self._bytecode[-1]
+
+        self._remove_last_bytecodes(1)  # remove push_block*
+
+        jump_offset_idx_to_skip_branch = emit_jump_on_bool_with_dummy_offset(
+            self, not is_or, True
+        )
+
+        to_be_inlined = self._literals[block_literal_idx]
+
+        self._is_currently_inlining_a_block = True
+        to_be_inlined.inline(self)
+        self._is_currently_inlining_a_block = False
+
+        jump_offset_idx_to_skip_push_true = emit_jump_with_dummy_offset(self)
+
+        self.patch_jump_offset_to_point_to_next_instruction(
+            jump_offset_idx_to_skip_branch, parser
+        )
+
+        emit_push_constant(self, trueObject if is_or else falseObject)
+
+        self.patch_jump_offset_to_point_to_next_instruction(
+            jump_offset_idx_to_skip_push_true, parser
+        )
+
+        self._reset_last_bytecode_buffer()
 
         return True
 

--- a/src/som/compiler/bc/parser.py
+++ b/src/som/compiler/bc/parser.py
@@ -233,6 +233,14 @@ class Parser(ParserBase):
 
         self._binary_operand(mgenc)
 
+        if not is_super_send and (
+            msg.get_embedded_string() == "||"
+            and mgenc.inline_andor(self, True)
+            or msg.get_embedded_string() == "&&"
+            and mgenc.inline_andor(self, False)
+        ):
+            return
+
         if is_super_send:
             emit_super_send(mgenc, msg)
         else:
@@ -268,6 +276,8 @@ class Parser(ParserBase):
                 )
                 or (keyword == "whileTrue:" and mgenc.inline_while(self, True))
                 or (keyword == "whileFalse:" and mgenc.inline_while(self, False))
+                or (keyword == "or:" and mgenc.inline_andor(self, True))
+                or (keyword == "and:" and mgenc.inline_andor(self, False))
             ):
                 return
 

--- a/src/som/interpreter/ast/nodes/specialized/literal_and_or.py
+++ b/src/som/interpreter/ast/nodes/specialized/literal_and_or.py
@@ -1,0 +1,38 @@
+from som.interpreter.ast.nodes.expression_node import ExpressionNode
+from som.vm.globals import trueObject, falseObject
+
+
+class AndInlinedNode(ExpressionNode):
+
+    _immutable_fields_ = ["_rcvr_expr?", "_arg_expr?"]
+    _child_nodes_ = ["_rcvr_expr", "_arg_expr"]
+
+    def __init__(self, rcvr_expr, arg_expr, source_section):
+        ExpressionNode.__init__(self, source_section)
+        self._rcvr_expr = self.adopt_child(rcvr_expr)
+        self._arg_expr = self.adopt_child(arg_expr)
+
+    def execute(self, frame):
+        result = self._rcvr_expr.execute(frame)
+        if result is trueObject:
+            return self._arg_expr.execute(frame)
+        assert result is falseObject
+        return falseObject
+
+
+class OrInlinedNode(ExpressionNode):
+
+    _immutable_fields_ = ["_rcvr_expr?", "_arg_expr?"]
+    _child_nodes_ = ["_rcvr_expr", "_arg_expr"]
+
+    def __init__(self, rcvr_expr, arg_expr, source_section):
+        ExpressionNode.__init__(self, source_section)
+        self._rcvr_expr = self.adopt_child(rcvr_expr)
+        self._arg_expr = self.adopt_child(arg_expr)
+
+    def execute(self, frame):
+        result = self._rcvr_expr.execute(frame)
+        if result is trueObject:
+            return trueObject
+        assert result is falseObject
+        return self._arg_expr.execute(frame)

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -270,101 +270,11 @@ _BYTECODE_LENGTH = [
     3,  # pop_argument
 ]
 
-# chose a unreasonable number to be recognizable
-_STACK_EFFECT_DEPENDS_ON_MESSAGE = -1000
-
-_BYTECODE_STACK_EFFECT = [
-    0,  # halt
-    1,  # dup
-    1,  # push_frame
-    1,  # push_frame_0
-    1,  # push_frame_1
-    1,  # push_frame_2
-    1,  # push_inner
-    1,  # push_inner_0
-    1,  # push_inner_1
-    1,  # push_inner_2
-    1,  # push_field
-    1,  # push_field_0
-    1,  # push_field_1
-    1,  # push_block
-    1,  # push_block_no_ctx
-    1,  # push_constant
-    1,  # push_constant_0
-    1,  # push_constant_1
-    1,  # push_constant_2
-    1,  # push_0
-    1,  # push_1
-    1,  # push_nil
-    1,  # push_global
-    -1,  # pop
-    -1,  # pop_frame
-    -1,  # pop_frame_0
-    -1,  # pop_frame_1
-    -1,  # pop_frame_2
-    -1,  # pop_inner
-    -1,  # pop_inner_0
-    -1,  # pop_inner_1
-    -1,  # pop_inner_2
-    -1,  # pop_field
-    -1,  # pop_field_0
-    -1,  # pop_field_1
-    _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # send_1
-    _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # send_2
-    _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # send_3
-    _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # send_n
-    _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # super_send
-    0,  # return_local
-    0,  # return_non_local
-    0,  # return_self
-    0,  # return_field_0
-    0,  # return_field_1
-    0,  # return_field_2
-    0,  # inc
-    0,  # dec
-    0,  # inc_field
-    1,  # inc_field_push
-    0,  # jump
-    0,  # jump_on_true_top_nil
-    0,  # jump_on_false_top_nil
-    -1,  # jump_on_true_pop
-    -1,  # jump_on_false_pop
-    0,  # jump_backward
-    0,  # jump2
-    0,  # jump2_on_true_top_nil
-    0,  # jump2_on_false_top_nil
-    -1,  # jump2_on_true_pop
-    -1,  # jump2_on_false_pop
-    0,  # jump2_backward
-    _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # q_super_send_1
-    _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # q_super_send_2
-    _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # q_super_send_3
-    _STACK_EFFECT_DEPENDS_ON_MESSAGE,  # q_super_send_n
-    1,  # push_argument
-    1,  # push_field
-    -1,  # pop_local
-    -1,  # pop_argument
-]
-
 
 @jit.elidable
 def bytecode_length(bytecode):
     assert 0 <= bytecode < len(_BYTECODE_LENGTH)
     return _BYTECODE_LENGTH[bytecode]
-
-
-@jit.elidable
-def bytecode_stack_effect(bytecode, number_of_arguments_of_message_send=0):
-    assert 0 <= bytecode < len(_BYTECODE_STACK_EFFECT)
-    if bytecode_stack_effect_depends_on_send(bytecode):
-        # +1 in order to account for the return value
-        return -number_of_arguments_of_message_send + 1
-    return _BYTECODE_STACK_EFFECT[bytecode]
-
-
-def bytecode_stack_effect_depends_on_send(bytecode):
-    assert 0 <= bytecode < len(_BYTECODE_STACK_EFFECT)
-    return _BYTECODE_STACK_EFFECT[bytecode] == _STACK_EFFECT_DEPENDS_ON_MESSAGE
 
 
 @jit.elidable

--- a/src/som/primitives/bc/integer_primitives.py
+++ b/src/som/primitives/bc/integer_primitives.py
@@ -36,7 +36,7 @@ def get_printable_location_down(block_method):
     from som.vmobjects.method_bc import BcAbstractMethod
 
     assert isinstance(block_method, BcAbstractMethod)
-    return "downToto:do: " % block_method.merge_point_string()
+    return "downToto:do: " + block_method.merge_point_string()
 
 
 jitdriver_int_down = jit.JitDriver(

--- a/src/som/primitives/bc/integer_primitives.py
+++ b/src/som/primitives/bc/integer_primitives.py
@@ -6,14 +6,11 @@ from som.vmobjects.integer import Integer
 from som.vmobjects.primitive import Primitive, TernaryPrimitive
 
 
-def get_printable_location(block_method):
+def get_printable_location_up(block_method):
     from som.vmobjects.method_bc import BcAbstractMethod
 
     assert isinstance(block_method, BcAbstractMethod)
-    return "to:do: [%s>>%s]" % (
-        block_method.get_holder().get_name().get_embedded_string(),
-        block_method.get_signature().get_embedded_string(),
-    )
+    return "to:do: " + block_method.merge_point_string()
 
 
 jitdriver_int = jit.JitDriver(
@@ -22,7 +19,7 @@ jitdriver_int = jit.JitDriver(
     reds="auto",
     # virtualizables=['frame'],
     is_recursive=True,
-    get_printable_location=get_printable_location,
+    get_printable_location=get_printable_location_up,
 )
 
 jitdriver_double = jit.JitDriver(
@@ -31,7 +28,33 @@ jitdriver_double = jit.JitDriver(
     reds="auto",
     # virtualizables=['frame'],
     is_recursive=True,
-    get_printable_location=get_printable_location,
+    get_printable_location=get_printable_location_up,
+)
+
+
+def get_printable_location_down(block_method):
+    from som.vmobjects.method_bc import BcAbstractMethod
+
+    assert isinstance(block_method, BcAbstractMethod)
+    return "downToto:do: " % block_method.merge_point_string()
+
+
+jitdriver_int_down = jit.JitDriver(
+    name="downTo:do: with int",
+    greens=["block_method"],
+    reds="auto",
+    # virtualizables=['frame'],
+    is_recursive=True,
+    get_printable_location=get_printable_location_down,
+)
+
+jitdriver_double_down = jit.JitDriver(
+    name="downTo:do: with double",
+    greens=["block_method"],
+    reds="auto",
+    # virtualizables=['frame'],
+    is_recursive=True,
+    get_printable_location=get_printable_location_down,
 )
 
 
@@ -105,8 +128,41 @@ def _to_by_do(_ivkbl, stack, stack_ptr):
     return stack_ptr
 
 
+def _down_to_do_int(i, by_increment, bottom, block, block_method):
+    assert isinstance(i, int)
+    assert isinstance(bottom, int)
+    while i >= bottom:
+        jitdriver_int_down.jit_merge_point(block_method=block_method)
+
+        block_method.invoke_2(block, Integer(i))
+        i -= by_increment
+
+
+def _down_to_do_double(i, by_increment, bottom, block, block_method):
+    assert isinstance(i, int)
+    assert isinstance(bottom, float)
+    while i >= bottom:
+        jitdriver_double_down.jit_merge_point(block_method=block_method)
+
+        block_method.invoke_2(block, Integer(i))
+        i -= by_increment
+
+
+def _down_to_do(rcvr, limit, block):
+    block_method = block.get_method()
+
+    i = rcvr.get_embedded_integer()
+    if isinstance(limit, Double):
+        _down_to_do_double(i, 1, limit.get_embedded_double(), block, block_method)
+    else:
+        _down_to_do_int(i, 1, limit.get_embedded_integer(), block, block_method)
+
+    return rcvr
+
+
 class IntegerPrimitives(_Base):
     def install_primitives(self):
         _Base.install_primitives(self)
         self._install_instance_primitive(TernaryPrimitive("to:do:", _to_do))
+        self._install_instance_primitive(TernaryPrimitive("downTo:do:", _down_to_do))
         self._install_instance_primitive(Primitive("to:by:do:", _to_by_do))

--- a/src/som/vmobjects/method_trivial.py
+++ b/src/som/vmobjects/method_trivial.py
@@ -1,5 +1,9 @@
 from rlib.jit import elidable_promote, unroll_safe
-from som.compiler.bc.bytecode_generator import emit_push_constant, emit_push_global
+from som.compiler.bc.bytecode_generator import (
+    emit_push_constant,
+    emit_push_global,
+    emit_push_field_with_index,
+)
 from som.interp_type import is_ast_interpreter
 from som.interpreter.ast.frame import FRAME_AND_INNER_RCVR_IDX
 from som.interpreter.bc.frame import stack_pop_old_arguments_and_push_result
@@ -174,7 +178,7 @@ class FieldRead(AbstractTrivialMethod):
     else:
 
         def inline(self, mgenc):
-            raise NotImplementedError()
+            emit_push_field_with_index(mgenc, self._field_idx, self._context_level - 1)
 
 
 class FieldWrite(AbstractTrivialMethod):

--- a/tests/test_ast_inlining.py
+++ b/tests/test_ast_inlining.py
@@ -522,6 +522,15 @@ def test_inlining_of_and(mgenc, and_sel):
     assert isinstance(ast._exprs[0], AndInlinedNode)
 
 
+def test_field_read_inlining(cgenc, mgenc):
+    add_field(cgenc, "field")
+    ast = parse_method(mgenc, "test = ( true and: [ field ] )")
+
+    assert isinstance(ast._exprs[0], AndInlinedNode)
+    and_expr = ast._exprs[0]
+    assert isinstance(and_expr._arg_expr, FieldReadNode)
+
+
 @pytest.mark.parametrize("or_sel", ["or:", "||"])
 def test_inlining_of_or(mgenc, or_sel):
     ast = parse_method(

--- a/tests/test_ast_inlining.py
+++ b/tests/test_ast_inlining.py
@@ -15,6 +15,10 @@ from som.interpreter.ast.nodes.literal_node import LiteralNode
 from som.interpreter.ast.nodes.return_non_local_node import ReturnLocalNode
 from som.interpreter.ast.nodes.sequence_node import SequenceNode
 from som.interpreter.ast.nodes.specialized.int_inc_node import IntIncrementNode
+from som.interpreter.ast.nodes.specialized.literal_and_or import (
+    AndInlinedNode,
+    OrInlinedNode,
+)
 from som.interpreter.ast.nodes.specialized.literal_if import (
     IfInlinedNode,
     IfElseInlinedNode,
@@ -507,3 +511,21 @@ def test_to_do_block_block_inlined_self(cgenc, mgenc):
     assert read_l2_node._context_level == 2
     assert read_l2_node.var._name == "l2"
     assert read_l2_node.var.idx == 1
+
+
+@pytest.mark.parametrize("and_sel", ["and:", "&&"])
+def test_inlining_of_and(mgenc, and_sel):
+    ast = parse_method(
+        mgenc, "test = ( true AND_SEL [ #val ] )".replace("AND_SEL", and_sel)
+    )
+
+    assert isinstance(ast._exprs[0], AndInlinedNode)
+
+
+@pytest.mark.parametrize("or_sel", ["or:", "||"])
+def test_inlining_of_or(mgenc, or_sel):
+    ast = parse_method(
+        mgenc, "test = ( true OR_SEL [ #val ] )".replace("OR_SEL", or_sel)
+    )
+
+    assert isinstance(ast._exprs[0], OrInlinedNode)

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -1318,11 +1318,11 @@ def test_inlining_of_and(mgenc, and_sel):
         mgenc, "test = ( true AND_SEL [ #val ] )".replace("AND_SEL", and_sel)
     )
 
-    assert len(bytecodes) == 12
+    assert len(bytecodes) == 11
     check(
         bytecodes,
         [
-            Bytecodes.push_global,
+            Bytecodes.push_constant_0,
             BC(Bytecodes.jump_on_false_pop, 7),
             # true branch
             Bytecodes.push_constant_2,  # push the `#val`
@@ -1341,17 +1341,17 @@ def test_inlining_of_or(mgenc, or_sel):
         mgenc, "test = ( true OR_SEL [ #val ] )".replace("OR_SEL", or_sel)
     )
 
-    assert len(bytecodes) == 12
+    assert len(bytecodes) == 10
     check(
         bytecodes,
         [
-            Bytecodes.push_global,
+            Bytecodes.push_constant_0,
             BC(Bytecodes.jump_on_true_pop, 7),
             # true branch
             Bytecodes.push_constant_2,  # push the `#val`
-            BC(Bytecodes.jump, 5),
+            BC(Bytecodes.jump, 4),
             # false branch, jump_on_true target, push true
-            Bytecodes.push_constant,
+            Bytecodes.push_constant_0,
             # target of the jump in the true branch
             Bytecodes.return_self,
         ],
@@ -1362,11 +1362,11 @@ def test_field_read_inlining(cgenc, mgenc):
     add_field(cgenc, "field")
     bytecodes = method_to_bytecodes(mgenc, "test = ( true and: [ field ] )")
 
-    assert len(bytecodes) == 11
+    assert len(bytecodes) == 10
     check(
         bytecodes,
         [
-            Bytecodes.push_global,
+            Bytecodes.push_constant_0,
             BC(Bytecodes.jump_on_false_pop, 7),
             # true branch
             Bytecodes.push_field_0,


### PR DESCRIPTION
This PR introduces a primitive implementation for Integer>>#downTo:do:, and inlines boolean operations with block arguments.

For the interpreters, this is a good win on a small set of benchmarks.
The SomSom benchmarks see run-time reductions of at most 1-2% though.

In the bytecode interpreter, Mandelbrot, Permute, and Towers see some wins.
Especially Permute also gains in the jitted performance.

In the AST interpreter, it's less pronounced, bit there a few small run time reductions.

https://rebench.stefan-marr.de/compare/RPySOM/14675664ec92067e66ddf22632605f223377cc37/c70d8b7d6d8df2db235c80f73b0227837fddc557#micro-somsom-SomSom-ast-interp