### PR TITLE
Run benchmarks in parallel on yuria 1,2,3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,21 +1,25 @@
 stages:
-  - build-test-benchmark
+  - build-test
+  - benchmark
+  - benchmark-completion
 
 variables:
   PYTHONUNBUFFERED: "true"
-  PYPY_DIR: /home/gitlab-runner/.local/pypy2.7-v7.3.1-src
+  PYPY_DIR: /home/gitlab-runner/.local/pypy2.7-v7.3.5-src
 
 before_script:
   - git submodule update --init
 
-bc_build_test_benchmark_job:
-  stage: build-test-benchmark
-  tags: [benchmarks, infinity]
+build-and-test-interpreters:
+  stage: build-test
+  tags: [yuria]
   script:
     # Setup
+    - export PROJECT_FOLDER=$(pwd)
     - export PYTHONPATH=$PYTHONPATH:$PYPY_DIR:src
     - export RPYTHON=$PYPY_DIR/rpython/bin/rpython
-    - export PATH=$PATH:/home/gitlab-runner/.local/pypy2.7-v7.3.1-linux64/bin
+    - export PATH=$PATH:/home/gitlab-runner/.local/pypy2.7-v7.3.5-linux64/bin
+
     - export SOM_INTERP=BC
     
     # Unit Tests
@@ -25,37 +29,130 @@ bc_build_test_benchmark_job:
     # Interpreter
     - $RPYTHON --batch src/main_rpython.py
     - ./som-bc-interp -cp Smalltalk TestSuite/TestHarness.som
-    
-    # JIT Compiled Version
-    - $RPYTHON --batch -Ojit src/main_rpython.py
-    - ./som-bc-jit -cp Smalltalk TestSuite/TestHarness.som
-    
-    # Run Benchmarks
-    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf all e:RPySOM-bc-jit e:RPySOM-bc-interp e:SomSom-bc-interp
-    # - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf
 
-ast_build_test_benchmark_job:
-  stage: build-test-benchmark
-  tags: [benchmarks, infinity]
-  script:
-    # Setup
-    - export PYTHONPATH=$PYTHONPATH:$PYPY_DIR:src
-    - export RPYTHON=$PYPY_DIR/rpython/bin/rpython
-    - export PATH=$PATH:/home/gitlab-runner/.local/pypy2.7-v7.3.1-linux64/bin
     - export SOM_INTERP=AST
     
     # Unit Tests
     - PYTHONPATH=src python3 -m pytest
     - ./som.sh -cp Smalltalk TestSuite/TestHarness.som
-
+    
     # Interpreter
     - $RPYTHON --batch src/main_rpython.py
     - ./som-ast-interp -cp Smalltalk TestSuite/TestHarness.som
+
+
+    # Package and Upload
+    - lz4 som-ast-interp som-ast-interp.lz4
+    - lz4 som-bc-interp  som-bc-interp.lz4
+    
+    - |
+      sftp tmp-artifacts << EOF
+        -mkdir incoming/${CI_PIPELINE_ID}/
+        put ${PROJECT_FOLDER}/som-ast-interp.lz4 incoming/${CI_PIPELINE_ID}/
+        put ${PROJECT_FOLDER}/som-bc-interp.lz4 incoming/${CI_PIPELINE_ID}/
+      EOF
+
+build-and-test-jit-bc:
+  stage: build-test
+  tags: [yuria2]
+  script:
+    # Setup
+    - export PROJECT_FOLDER=$(pwd)
+    - export PYTHONPATH=$PYTHONPATH:$PYPY_DIR:src
+    - export RPYTHON=$PYPY_DIR/rpython/bin/rpython
+    - export PATH=$PATH:/home/gitlab-runner/.local/pypy2.7-v7.3.5-linux64/bin
+    - export SOM_INTERP=BC
+    
+    # JIT Compiled Version
+    - $RPYTHON --batch -Ojit src/main_rpython.py
+    - ./som-bc-jit -cp Smalltalk TestSuite/TestHarness.som
+
+    # Package and Upload
+    - lz4 som-bc-jit som-bc-jit.lz4
+    
+    - |
+      sftp tmp-artifacts << EOF
+        -mkdir incoming/${CI_PIPELINE_ID}/
+        put ${PROJECT_FOLDER}/som-bc-jit.lz4 incoming/${CI_PIPELINE_ID}/
+      EOF
+
+build-and-test-jit-ast:
+  stage: build-test
+  tags: [yuria3]
+  script:
+    # Setup
+    - export PROJECT_FOLDER=$(pwd)
+    - export PYTHONPATH=$PYTHONPATH:$PYPY_DIR:src
+    - export RPYTHON=$PYPY_DIR/rpython/bin/rpython
+    - export PATH=$PATH:/home/gitlab-runner/.local/pypy2.7-v7.3.5-linux64/bin
+    - export SOM_INTERP=AST
     
     # JIT Compiled Version
     - $RPYTHON --batch -Ojit src/main_rpython.py
     - ./som-ast-jit -cp Smalltalk TestSuite/TestHarness.som
+
+    # Package and Upload
+    - lz4 som-ast-jit som-ast-jit.lz4
     
+    - |
+      sftp tmp-artifacts << EOF
+        -mkdir incoming/${CI_PIPELINE_ID}/
+        put ${PROJECT_FOLDER}/som-ast-jit.lz4 incoming/${CI_PIPELINE_ID}/
+      EOF
+
+benchmark-y1:
+  stage: benchmark
+  tags: [yuria]
+  script:
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-jit.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-interp.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-jit.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-interp.lz4
+    
+    - lz4 -d som-ast-jit.lz4    som-ast-jit
+    - lz4 -d som-ast-interp.lz4 som-ast-interp
+    - lz4 -d som-bc-jit.lz4     som-bc-jit
+    - lz4 -d som-bc-interp.lz4  som-bc-interp
+
     # Run Benchmarks
-    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf all e:RPySOM-ast-jit e:RPySOM-ast-interp e:SomSom-ast-interp
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria
+
+benchmark-y2:
+  stage: benchmark
+  tags: [yuria2]
+  script:
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-jit.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-interp.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-jit.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-interp.lz4
+    
+    - lz4 -d som-ast-jit.lz4    som-ast-jit
+    - lz4 -d som-ast-interp.lz4 som-ast-interp
+    - lz4 -d som-bc-jit.lz4     som-bc-jit
+    - lz4 -d som-bc-interp.lz4  som-bc-interp
+
+    # Run Benchmarks
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria2
+
+benchmark-y3:
+  stage: benchmark
+  tags: [yuria3]
+  script:
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-jit.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-interp.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-jit.lz4
+    - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-interp.lz4
+    
+    - lz4 -d som-ast-jit.lz4    som-ast-jit
+    - lz4 -d som-ast-interp.lz4 som-ast-interp
+    - lz4 -d som-bc-jit.lz4     som-bc-jit
+    - lz4 -d som-bc-interp.lz4  som-bc-interp
+
+    # Run Benchmarks
+    - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf m:yuria3
+
+report-completion:
+  stage: benchmark-completion
+  tags: [yuria]
+  script:
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf

--- a/rebench.conf
+++ b/rebench.conf
@@ -22,23 +22,23 @@ benchmark_suites:
         iterations: 1
         invocations: 5
         benchmarks:
-            - Richards:     {extra_args: 1}
-            - DeltaBlue:    {extra_args: 100}
-            - NBody:        {extra_args: 1000}
-            - Json:         {extra_args: 1}
-            - GraphSearch:  {extra_args: 7}
-            - PageRank:     {extra_args: 75}
+            - Richards:     {extra_args:    1, machines: [yuria ]}
+            - DeltaBlue:    {extra_args:  100, machines: [yuria2]}
+            - NBody:        {extra_args: 1000, machines: [yuria3]}
+            - Json:         {extra_args:    1, machines: [yuria ]}
+            - GraphSearch:  {extra_args:    7, machines: [yuria2]}
+            - PageRank:     {extra_args:   75, machines: [yuria3]}
 
     macro-steady:
         gauge_adapter: RebenchLog
         command: *MACRO_CMD
         benchmarks:
-            - Richards:     {extra_args: 40,     warmup:  30,   iterations: 130}
-            - DeltaBlue:    {extra_args: 10000,  warmup:  20,   iterations: 120}
-            - NBody:        {extra_args: 200000, warmup:  20,   iterations: 120}
-            - Json:         {extra_args: 80,     warmup:  20,   iterations: 120}
-            - GraphSearch:  {extra_args: 25,     warmup: 100,   iterations: 250}
-            - PageRank:     {extra_args: 1000,   warmup:  20,   iterations: 120}
+            - Richards:     {extra_args: 40,     warmup:  30,   iterations: 130, machines: [yuria ]}
+            - DeltaBlue:    {extra_args: 10000,  warmup:  20,   iterations: 120, machines: [yuria2]}
+            - NBody:        {extra_args: 200000, warmup:  20,   iterations: 120, machines: [yuria3]}
+            - Json:         {extra_args: 80,     warmup:  20,   iterations: 120, machines: [yuria ]}
+            - GraphSearch:  {extra_args: 25,     warmup: 100,   iterations: 250, machines: [yuria2]}
+            - PageRank:     {extra_args: 1000,   warmup:  20,   iterations: 120, machines: [yuria3]}
 
 
     micro-startup:
@@ -47,62 +47,62 @@ benchmark_suites:
         iterations: 1
         invocations: 5
         benchmarks:
-            - Fannkuch:     {extra_args: 7}
-            - Fibonacci:    {extra_args: 10}
-            - Dispatch:     {extra_args: 10}
-            - Bounce:       {extra_args: 10}
-            - Loop:         {extra_args: 100}
-            - Permute:      {extra_args: 10}
-            - Queens:       {extra_args: 10}
-            - List:         {extra_args: 2}
-            - Recurse:      {extra_args: 12}
-            - Storage:      {extra_args: 8}
-            - Sieve:        {extra_args: 20}
-            - BubbleSort:   {extra_args: 15}
-            - QuickSort:    {extra_args: 15}
-            - Sum:          {extra_args: 40}
-            - Towers:       {extra_args: 2}
-            - TreeSort:     {extra_args: 7}
-            - IntegerLoop:  {extra_args: 7}
-            - FieldLoop:    {extra_args: 1}
-            - WhileLoop:    {extra_args: 30}
-            - Mandelbrot:   {extra_args: 50}
+            - Fannkuch:     {extra_args:   7, machines: [yuria ]}
+            - Fibonacci:    {extra_args:  10, machines: [yuria2]}
+            - Dispatch:     {extra_args:  10, machines: [yuria3]}
+            - Bounce:       {extra_args:  10, machines: [yuria ]}
+            - Loop:         {extra_args: 100, machines: [yuria2]}
+            - Permute:      {extra_args:  10, machines: [yuria3]}
+            - Queens:       {extra_args:  10, machines: [yuria ]}
+            - List:         {extra_args:   2, machines: [yuria2]}
+            - Recurse:      {extra_args:  12, machines: [yuria3]}
+            - Storage:      {extra_args:   8, machines: [yuria ]}
+            - Sieve:        {extra_args:  20, machines: [yuria2]}
+            - BubbleSort:   {extra_args:  15, machines: [yuria3]}
+            - QuickSort:    {extra_args:  15, machines: [yuria ]}
+            - Sum:          {extra_args:  40, machines: [yuria2]}
+            - Towers:       {extra_args:   2, machines: [yuria3]}
+            - TreeSort:     {extra_args:   7, machines: [yuria ]}
+            - IntegerLoop:  {extra_args:   7, machines: [yuria2]}
+            - FieldLoop:    {extra_args:   1, machines: [yuria3]}
+            - WhileLoop:    {extra_args:  30, machines: [yuria ]}
+            - Mandelbrot:   {extra_args:  50, machines: [yuria2]}
 
     micro-steady:
         gauge_adapter: RebenchLog
         command: *MICRO_CMD
         benchmarks:
-            - Fannkuch:     {extra_args: 9,      warmup:   5,   iterations:  55}
-            - Fibonacci:    {extra_args: 1000,   warmup:  10,   iterations:  60}
-            - Dispatch:     {extra_args: 10000,  warmup:   5,   iterations:  55}
-            - Bounce:       {extra_args: 4000,   warmup:  10,   iterations:  60}
-            - Loop:         {extra_args: 10000,  warmup:   5,   iterations:  55}
-            - Permute:      {extra_args: 1500,   warmup:   5,   iterations:  55}
-            - Queens:       {extra_args: 1000,   warmup:   5,   iterations:  55}
-            - List:         {extra_args: 1000,   warmup:  15,   iterations:  65}
-            - Recurse:      {extra_args: 2000,   warmup:  15,   iterations:  65}
-            - Storage:      {extra_args: 1000,   warmup:  10,   iterations:  60}
-            - Sieve:        {extra_args: 2500,   warmup:  10,   iterations:  60}
-            - BubbleSort:   {extra_args: 3000,   warmup:   5,   iterations:  55}
-            - QuickSort:    {extra_args: 2000,   warmup:   5,   iterations:  55}
-            - Sum:          {extra_args: 10000,  warmup:   5,   iterations:  55}
-            - Towers:       {extra_args: 1000,   warmup:   5,   iterations:  55}
-            - TreeSort:     {extra_args: 1000,   warmup:  10,   iterations:  60}
-            - IntegerLoop:  {extra_args: 8000,   warmup:   5,   iterations:  55}
-            - FieldLoop:    {extra_args: 900,    warmup:   5,   iterations:  55}
-            - WhileLoop:    {extra_args: 9000,   warmup:   5,   iterations:  55}
-            - Mandelbrot:   {extra_args: 1000,   warmup:  10,   iterations: 110}
+            - Fannkuch:     {extra_args: 9,      warmup:   5,   iterations:  55, machines: [yuria ]}
+            - Fibonacci:    {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria2]}
+            - Dispatch:     {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria3]}
+            - Bounce:       {extra_args: 4000,   warmup:  10,   iterations:  60, machines: [yuria ]}
+            - Loop:         {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria2]}
+            - Permute:      {extra_args: 1500,   warmup:   5,   iterations:  55, machines: [yuria3]}
+            - Queens:       {extra_args: 1000,   warmup:   5,   iterations:  55, machines: [yuria ]}
+            - List:         {extra_args: 1000,   warmup:  15,   iterations:  65, machines: [yuria2]}
+            - Recurse:      {extra_args: 2000,   warmup:  15,   iterations:  65, machines: [yuria3]}
+            - Storage:      {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria ]}
+            - Sieve:        {extra_args: 2500,   warmup:  10,   iterations:  60, machines: [yuria2]}
+            - BubbleSort:   {extra_args: 3000,   warmup:   5,   iterations:  55, machines: [yuria3]}
+            - QuickSort:    {extra_args: 2000,   warmup:   5,   iterations:  55, machines: [yuria ]}
+            - Sum:          {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria2]}
+            - Towers:       {extra_args: 1000,   warmup:   5,   iterations:  55, machines: [yuria3]}
+            - TreeSort:     {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria ]}
+            - IntegerLoop:  {extra_args: 8000,   warmup:   5,   iterations:  55, machines: [yuria2]}
+            - FieldLoop:    {extra_args: 900,    warmup:   5,   iterations:  55, machines: [yuria3]}
+            - WhileLoop:    {extra_args: 9000,   warmup:   5,   iterations:  55, machines: [yuria2]}
+            - Mandelbrot:   {extra_args: 1000,   warmup:  10,   iterations: 110, machines: [yuria3]}
 
     micro-somsom:
         gauge_adapter: RebenchLog
         command: "-cp Smalltalk:Examples/Benchmarks/LanguageFeatures Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 0 "
         iterations: 1
         benchmarks:
-            - Loop:         {extra_args: 1}
-            - Queens:       {extra_args: 1}
-            - List:         {extra_args: 1}
-            - Recurse:      {extra_args: 1}
-            - Mandelbrot:   {extra_args: 3}
+            - Loop:         {extra_args: 1, machines: [yuria3]}
+            - Queens:       {extra_args: 1, machines: [yuria ]}
+            - List:         {extra_args: 1, machines: [yuria2]}
+            - Recurse:      {extra_args: 1, machines: [yuria3]}
+            - Mandelbrot:   {extra_args: 3, machines: [yuria ]}
 
 executors:
     RPySOM-ast-interp:

--- a/rebench.conf
+++ b/rebench.conf
@@ -79,7 +79,7 @@ benchmark_suites:
             - Loop:         {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria2]}
             - Permute:      {extra_args: 1500,   warmup:   5,   iterations:  55, machines: [yuria3]}
             - Queens:       {extra_args: 1000,   warmup:   5,   iterations:  55, machines: [yuria ]}
-            - List:         {extra_args: 1000,   warmup:  15,   iterations:  65, machines: [yuria2]}
+            - List:         {extra_args: 1000,   warmup:  15,   iterations:  65, machines: [yuria ]}
             - Recurse:      {extra_args: 2000,   warmup:  15,   iterations:  65, machines: [yuria ]}
             - Storage:      {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria ]}
             - Sieve:        {extra_args: 2500,   warmup:  10,   iterations:  60, machines: [yuria2]}

--- a/rebench.conf
+++ b/rebench.conf
@@ -73,14 +73,14 @@ benchmark_suites:
         command: *MICRO_CMD
         benchmarks:
             - Fannkuch:     {extra_args: 9,      warmup:   5,   iterations:  55, machines: [yuria ]}
-            - Fibonacci:    {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria2]}
+            - Fibonacci:    {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria ]}
             - Dispatch:     {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria3]}
             - Bounce:       {extra_args: 4000,   warmup:  10,   iterations:  60, machines: [yuria ]}
             - Loop:         {extra_args: 10000,  warmup:   5,   iterations:  55, machines: [yuria2]}
             - Permute:      {extra_args: 1500,   warmup:   5,   iterations:  55, machines: [yuria3]}
             - Queens:       {extra_args: 1000,   warmup:   5,   iterations:  55, machines: [yuria ]}
             - List:         {extra_args: 1000,   warmup:  15,   iterations:  65, machines: [yuria2]}
-            - Recurse:      {extra_args: 2000,   warmup:  15,   iterations:  65, machines: [yuria3]}
+            - Recurse:      {extra_args: 2000,   warmup:  15,   iterations:  65, machines: [yuria ]}
             - Storage:      {extra_args: 1000,   warmup:  10,   iterations:  60, machines: [yuria ]}
             - Sieve:        {extra_args: 2500,   warmup:  10,   iterations:  60, machines: [yuria2]}
             - BubbleSort:   {extra_args: 3000,   warmup:   5,   iterations:  55, machines: [yuria3]}


### PR DESCRIPTION
This PR changes the GitLab setup to run benchmarks in parallel.

It uses a new ReBench feature to mark benchmarks with machines they should run on, and then filter by machine.

Previously, we had two jobs, one for AST and one for the BC interpreter.
Now we first compile binaries, also in parallel, and then run benchmarks.