### PR TITLE
Adopt Inline Caching from AST interpreter in BC one

### DIFF
--- a/src/som/interpreter/ast/nodes/dispatch.py
+++ b/src/som/interpreter/ast/nodes/dispatch.py
@@ -67,6 +67,14 @@ class GenericDispatchNode(_AbstractDispatchNode):
             return method.invoke_args(rcvr, args)
         return self._send_dnu(rcvr, args)
 
+    def dispatch_n_bc(self, stack, stack_ptr, rcvr):
+        method = rcvr.get_object_layout(self.universe).lookup_invokable(self._selector)
+        if method is not None:
+            return method.invoke_n(stack, stack_ptr)
+        from som.interpreter.bc.interpreter import send_does_not_understand
+
+        return send_does_not_understand(rcvr, self._selector, stack, stack_ptr)
+
 
 class CachedDispatchNode(_AbstractDispatchNode):
     _immutable_fields_ = ["_cached_method"]
@@ -86,6 +94,9 @@ class CachedDispatchNode(_AbstractDispatchNode):
 
     def dispatch_args(self, rcvr, args):
         return self._cached_method.invoke_args(rcvr, args)
+
+    def dispatch_n_bc(self, stack, stack_ptr, _rcvr):
+        return self._cached_method.invoke_n(stack, stack_ptr)
 
 
 class CachedDnuNode(_AbstractDispatchNode):

--- a/src/som/interpreter/ast/nodes/message/generic_node.py
+++ b/src/som/interpreter/ast/nodes/message/generic_node.py
@@ -8,6 +8,7 @@ from som.interpreter.ast.nodes.dispatch import (
     GenericDispatchNode,
 )
 from som.interpreter.ast.nodes.expression_node import ExpressionNode
+from som.interpreter.send import get_clean_inline_cache_and_size
 
 
 class _AbstractGenericMessageNode(ExpressionNode):
@@ -36,24 +37,6 @@ class _AbstractGenericMessageNode(ExpressionNode):
 
         return None
 
-    def _get_cache_size_and_drop_old_entries(self):
-        size = 0
-        prev = None
-        cache = self._dispatch
-        while cache is not None:
-            if not cache.expected_layout.is_latest:
-                # drop old layout from cache
-                if prev is None:
-                    self._dispatch = cache.next_entry
-                else:
-                    prev.next_entry = cache.next_entry
-            else:
-                size += 1
-                prev = cache
-
-            cache = cache.next_entry
-        return size
-
     def _specialize(self, layout, obj):
         if not layout.is_latest:
             obj.update_layout_to_match_class()
@@ -62,7 +45,8 @@ class _AbstractGenericMessageNode(ExpressionNode):
             if cache is not None:
                 return cache
 
-        cache_size = self._get_cache_size_and_drop_old_entries()
+        self._dispatch, cache_size = get_clean_inline_cache_and_size(self._dispatch)
+
         if cache_size < INLINE_CACHE_SIZE:
             method = layout.lookup_invokable(self._selector)
 

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -42,13 +42,10 @@ def _do_super_send(bytecode_index, method, stack, stack_ptr):
     receiver = stack[stack_ptr - (num_args - 1)]
 
     if invokable:
-        first = method.get_inline_cache(bytecode_index)
         method.set_inline_cache(
-            bytecode_index,
-            CachedDispatchNode(
-                receiver_class.get_layout_for_instances(), invokable, first
-            ),
+            bytecode_index, CachedDispatchNode(None, invokable, None)
         )
+
         if num_args == 1:
             bc = Bytecodes.q_super_send_1
         elif num_args == 2:

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -21,7 +21,6 @@ from som.interpreter.send import (
     lookup_and_send_2,
     lookup_and_send_3,
     get_inline_cache_size,
-    get_clean_inline_cache_and_size,
 )
 from som.vm.globals import nilObject, trueObject, falseObject
 from som.vmobjects.array import Array
@@ -727,11 +726,7 @@ def _lookup(layout, selector, method, bytecode_index, universe):
 def _update_object_and_invalidate_old_caches(obj, method, bytecode_index, universe):
     obj.update_layout_to_match_class()
     obj.get_object_layout(universe)
-
-    old_cache = method.get_inline_cache(bytecode_index)
-    method.set_inline_cache(
-        bytecode_index, get_clean_inline_cache_and_size(old_cache)[0]
-    )
+    method.drop_old_inline_cache_entries(bytecode_index)
 
 
 def send_does_not_understand(receiver, selector, stack, stack_ptr):

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -365,7 +365,7 @@ def interpret(method, frame, max_stack_size):
                 layout, signature, method, current_bc_idx, current_universe
             )
 
-            if isinstance(layout, GenericDispatchNode) and not layout.is_latest:
+            if not layout.is_latest:
                 _update_object_and_invalidate_old_caches(
                     receiver, method, current_bc_idx, current_universe
                 )
@@ -381,7 +381,7 @@ def interpret(method, frame, max_stack_size):
                 layout, signature, method, current_bc_idx, current_universe
             )
 
-            if isinstance(layout, GenericDispatchNode) and not layout.is_latest:
+            if not layout.is_latest:
                 _update_object_and_invalidate_old_caches(
                     receiver, method, current_bc_idx, current_universe
                 )
@@ -402,7 +402,7 @@ def interpret(method, frame, max_stack_size):
                 layout, signature, method, current_bc_idx, current_universe
             )
 
-            if isinstance(layout, GenericDispatchNode) and not layout.is_latest:
+            if not layout.is_latest:
                 _update_object_and_invalidate_old_caches(
                     receiver, method, current_bc_idx, current_universe
                 )
@@ -427,7 +427,7 @@ def interpret(method, frame, max_stack_size):
                 layout, signature, method, current_bc_idx, current_universe
             )
 
-            if isinstance(layout, GenericDispatchNode) and not layout.is_latest:
+            if not layout.is_latest:
                 _update_object_and_invalidate_old_caches(
                     receiver, method, current_bc_idx, current_universe
                 )

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -6,13 +6,23 @@ from som.interpreter.ast.frame import (
     FRAME_AND_INNER_RCVR_IDX,
     get_inner_as_context,
 )
+from som.interpreter.ast.nodes.dispatch import (
+    CachedDispatchNode,
+    INLINE_CACHE_SIZE,
+    GenericDispatchNode,
+)
 from som.interpreter.bc.bytecodes import bytecode_length, Bytecodes, bytecode_as_str
 from som.interpreter.bc.frame import (
     get_block_at,
     get_self_dynamically,
 )
 from som.interpreter.control_flow import ReturnException
-from som.interpreter.send import lookup_and_send_2, lookup_and_send_3
+from som.interpreter.send import (
+    lookup_and_send_2,
+    lookup_and_send_3,
+    get_inline_cache_size,
+    get_clean_inline_cache_and_size,
+)
 from som.vm.globals import nilObject, trueObject, falseObject
 from som.vmobjects.array import Array
 from som.vmobjects.block_bc import BcBlock
@@ -32,8 +42,12 @@ def _do_super_send(bytecode_index, method, stack, stack_ptr):
     receiver = stack[stack_ptr - (num_args - 1)]
 
     if invokable:
+        first = method.get_inline_cache(bytecode_index)
         method.set_inline_cache(
-            bytecode_index, receiver_class.get_layout_for_instances(), invokable
+            bytecode_index,
+            CachedDispatchNode(
+                receiver_class.get_layout_for_instances(), invokable, first
+            ),
         )
         if num_args == 1:
             bc = Bytecodes.q_super_send_1
@@ -48,7 +62,7 @@ def _do_super_send(bytecode_index, method, stack, stack_ptr):
             invokable, num_args, receiver, stack, stack_ptr
         )
     else:
-        stack_ptr = _send_does_not_understand(
+        stack_ptr = send_does_not_understand(
             receiver, invokable.get_signature(), stack, stack_ptr
         )
     return stack_ptr
@@ -351,66 +365,60 @@ def interpret(method, frame, max_stack_size):
             receiver = stack[stack_ptr]
 
             layout = receiver.get_object_layout(current_universe)
-            invokable = _lookup(layout, signature, method, current_bc_idx)
-            if invokable is not None:
-                stack[stack_ptr] = invokable.invoke_1(receiver)
-            elif not layout.is_latest:
+            dispatch_node = _lookup(
+                layout, signature, method, current_bc_idx, current_universe
+            )
+
+            if isinstance(layout, GenericDispatchNode) and not layout.is_latest:
                 _update_object_and_invalidate_old_caches(
                     receiver, method, current_bc_idx, current_universe
                 )
-                next_bc_idx = current_bc_idx
-            else:
-                stack_ptr = _send_does_not_understand(
-                    receiver, signature, stack, stack_ptr
-                )
+
+            stack[stack_ptr] = dispatch_node.dispatch_1(receiver)
 
         elif bytecode == Bytecodes.send_2:
             signature = method.get_constant(current_bc_idx)
             receiver = stack[stack_ptr - 1]
 
             layout = receiver.get_object_layout(current_universe)
-            invokable = _lookup(layout, signature, method, current_bc_idx)
-            if invokable is not None:
-                arg = stack[stack_ptr]
-                if we_are_jitted():
-                    stack[stack_ptr] = None
-                stack_ptr -= 1
-                stack[stack_ptr] = invokable.invoke_2(receiver, arg)
-            elif not layout.is_latest:
+            dispatch_node = _lookup(
+                layout, signature, method, current_bc_idx, current_universe
+            )
+
+            if isinstance(layout, GenericDispatchNode) and not layout.is_latest:
                 _update_object_and_invalidate_old_caches(
                     receiver, method, current_bc_idx, current_universe
                 )
-                next_bc_idx = current_bc_idx
-            else:
-                stack_ptr = _send_does_not_understand(
-                    receiver, signature, stack, stack_ptr
-                )
+
+            arg = stack[stack_ptr]
+            if we_are_jitted():
+                stack[stack_ptr] = None
+
+            stack_ptr -= 1
+            stack[stack_ptr] = dispatch_node.dispatch_2(receiver, arg)
 
         elif bytecode == Bytecodes.send_3:
             signature = method.get_constant(current_bc_idx)
             receiver = stack[stack_ptr - 2]
 
             layout = receiver.get_object_layout(current_universe)
-            invokable = _lookup(layout, signature, method, current_bc_idx)
-            if invokable is not None:
-                arg2 = stack[stack_ptr]
-                arg1 = stack[stack_ptr - 1]
+            dispatch_node = _lookup(
+                layout, signature, method, current_bc_idx, current_universe
+            )
 
-                if we_are_jitted():
-                    stack[stack_ptr] = None
-                    stack[stack_ptr - 1] = None
-
-                stack_ptr -= 2
-                stack[stack_ptr] = invokable.invoke_3(receiver, arg1, arg2)
-            elif not layout.is_latest:
+            if isinstance(layout, GenericDispatchNode) and not layout.is_latest:
                 _update_object_and_invalidate_old_caches(
                     receiver, method, current_bc_idx, current_universe
                 )
-                next_bc_idx = current_bc_idx
-            else:
-                stack_ptr = _send_does_not_understand(
-                    receiver, signature, stack, stack_ptr
-                )
+
+            arg2 = stack[stack_ptr]
+            arg1 = stack[stack_ptr - 1]
+            if we_are_jitted():
+                stack[stack_ptr] = None
+                stack[stack_ptr - 1] = None
+
+            stack_ptr -= 2
+            stack[stack_ptr] = dispatch_node.dispatch_3(receiver, arg1, arg2)
 
         elif bytecode == Bytecodes.send_n:
             signature = method.get_constant(current_bc_idx)
@@ -419,18 +427,16 @@ def interpret(method, frame, max_stack_size):
             ]
 
             layout = receiver.get_object_layout(current_universe)
-            invokable = _lookup(layout, signature, method, current_bc_idx)
-            if invokable is not None:
-                stack_ptr = invokable.invoke_n(stack, stack_ptr)
-            elif not layout.is_latest:
+            dispatch_node = _lookup(
+                layout, signature, method, current_bc_idx, current_universe
+            )
+
+            if isinstance(layout, GenericDispatchNode) and not layout.is_latest:
                 _update_object_and_invalidate_old_caches(
                     receiver, method, current_bc_idx, current_universe
                 )
-                next_bc_idx = current_bc_idx
-            else:
-                stack_ptr = _send_does_not_understand(
-                    receiver, signature, stack, stack_ptr
-                )
+
+            stack_ptr = dispatch_node.dispatch_n_bc(stack, stack_ptr, receiver)
 
         elif bytecode == Bytecodes.super_send:
             stack_ptr = _do_super_send(current_bc_idx, method, stack, stack_ptr)
@@ -628,30 +634,30 @@ def interpret(method, frame, max_stack_size):
             )
 
         elif bytecode == Bytecodes.q_super_send_1:
-            invokable = method.get_inline_cache_invokable(current_bc_idx)
-            stack[stack_ptr] = invokable.invoke_1(stack[stack_ptr])
+            dispatch_node = method.get_inline_cache(current_bc_idx)
+            stack[stack_ptr] = dispatch_node.dispatch_1(stack[stack_ptr])
 
         elif bytecode == Bytecodes.q_super_send_2:
-            invokable = method.get_inline_cache_invokable(current_bc_idx)
+            dispatch_node = method.get_inline_cache(current_bc_idx)
             arg = stack[stack_ptr]
             if we_are_jitted():
                 stack[stack_ptr] = None
             stack_ptr -= 1
-            stack[stack_ptr] = invokable.invoke_2(stack[stack_ptr], arg)
+            stack[stack_ptr] = dispatch_node.dispatch_2(stack[stack_ptr], arg)
 
         elif bytecode == Bytecodes.q_super_send_3:
-            invokable = method.get_inline_cache_invokable(current_bc_idx)
+            dispatch_node = method.get_inline_cache(current_bc_idx)
             arg2 = stack[stack_ptr]
             arg1 = stack[stack_ptr - 1]
             if we_are_jitted():
                 stack[stack_ptr] = None
                 stack[stack_ptr - 1] = None
             stack_ptr -= 2
-            stack[stack_ptr] = invokable.invoke_3(stack[stack_ptr], arg1, arg2)
+            stack[stack_ptr] = dispatch_node.dispatch_3(stack[stack_ptr], arg1, arg2)
 
         elif bytecode == Bytecodes.q_super_send_n:
-            invokable = method.get_inline_cache_invokable(current_bc_idx)
-            stack_ptr = invokable.invoke_n(stack, stack_ptr)
+            dispatch_node = method.get_inline_cache(current_bc_idx)
+            stack_ptr = dispatch_node.dispatch_n_bc(stack, stack_ptr, None)
 
         elif bytecode == Bytecodes.push_local:
             method.patch_variable_access(current_bc_idx)
@@ -701,42 +707,37 @@ def get_self(frame, ctx_level):
 
 
 @elidable_promote("all")
-def _lookup(layout, selector, method, bytecode_index):
-    # First try of inline cache
-    cached_layout1 = method.get_inline_cache_layout(bytecode_index)
-    if cached_layout1 is layout:
-        invokable = method.get_inline_cache_invokable(bytecode_index)
-    elif cached_layout1 is None:
-        invokable = layout.lookup_invokable(selector)
-        method.set_inline_cache(bytecode_index, layout, invokable)
-    else:
-        # second try
-        # the bytecode index after the send is used by the selector constant,
-        # and can be used safely as another cache item
-        cached_layout2 = method.get_inline_cache_layout(bytecode_index + 1)
-        if cached_layout2 == layout:
-            invokable = method.get_inline_cache_invokable(bytecode_index + 1)
-        else:
-            invokable = layout.lookup_invokable(selector)
-            if cached_layout2 is None:
-                method.set_inline_cache(bytecode_index + 1, layout, invokable)
-    return invokable
+def _lookup(layout, selector, method, bytecode_index, universe):
+    cache = first = method.get_inline_cache(bytecode_index)
+    while cache is not None:
+        if cache.expected_layout is layout:
+            return cache
+        cache = cache.next_entry
+
+    cache_size = get_inline_cache_size(first)
+    if INLINE_CACHE_SIZE >= cache_size:
+        invoke = layout.lookup_invokable(selector)
+        if invoke is not None:
+            new_dispatch_node = CachedDispatchNode(
+                rcvr_class=layout, method=invoke, next_entry=first
+            )
+            method.set_inline_cache(bytecode_index, new_dispatch_node)
+            return new_dispatch_node
+
+    return GenericDispatchNode(selector, universe)
 
 
 def _update_object_and_invalidate_old_caches(obj, method, bytecode_index, universe):
     obj.update_layout_to_match_class()
     obj.get_object_layout(universe)
 
-    cached_layout1 = method.get_inline_cache_layout(bytecode_index)
-    if cached_layout1 is not None and not cached_layout1.is_latest:
-        method.set_inline_cache(bytecode_index, None, None)
-
-    cached_layout2 = method.get_inline_cache_layout(bytecode_index + 1)
-    if cached_layout2 is not None and not cached_layout2.is_latest:
-        method.set_inline_cache(bytecode_index + 1, None, None)
+    old_cache = method.get_inline_cache(bytecode_index)
+    method.set_inline_cache(
+        bytecode_index, get_clean_inline_cache_and_size(old_cache)[0]
+    )
 
 
-def _send_does_not_understand(receiver, selector, stack, stack_ptr):
+def send_does_not_understand(receiver, selector, stack, stack_ptr):
     # ignore self
     number_of_arguments = selector.get_number_of_signature_arguments() - 1
     arguments_array = Array.from_size(number_of_arguments)

--- a/src/som/interpreter/send.py
+++ b/src/som/interpreter/send.py
@@ -16,3 +16,31 @@ def lookup_and_send_3(receiver, arg1, arg2, selector_string):
     selector = symbol_for(selector_string)
     invokable = receiver.get_class(current_universe).lookup_invokable(selector)
     return invokable.invoke_3(receiver, arg1, arg2)
+
+
+def get_inline_cache_size(cache):
+    size = 0
+    while cache is not None:
+        size += 1
+        cache = cache.next_entry
+    return size
+
+
+def get_clean_inline_cache_and_size(cache):
+    prev = None
+    new_cache = cache
+    size = 0
+
+    while cache is not None:
+        if not cache.expected_layout.is_latest:
+            if prev is None:
+                new_cache = cache.next_entry
+            else:
+                prev.next_entry = cache.next_entry
+        else:
+            prev = cache
+            size += 1
+
+        cache = cache.next_entry
+
+    return new_cache, size

--- a/src/som/interpreter/send.py
+++ b/src/som/interpreter/send.py
@@ -24,23 +24,3 @@ def get_inline_cache_size(cache):
         size += 1
         cache = cache.next_entry
     return size
-
-
-def get_clean_inline_cache_and_size(cache):
-    prev = None
-    new_cache = cache
-    size = 0
-
-    while cache is not None:
-        if not cache.expected_layout.is_latest:
-            if prev is None:
-                new_cache = cache.next_entry
-            else:
-                prev.next_entry = cache.next_entry
-        else:
-            prev = cache
-            size += 1
-
-        cache = cache.next_entry
-
-    return new_cache, size

--- a/src/som/interpreter/send.py
+++ b/src/som/interpreter/send.py
@@ -16,11 +16,3 @@ def lookup_and_send_3(receiver, arg1, arg2, selector_string):
     selector = symbol_for(selector_string)
     invokable = receiver.get_class(current_universe).lookup_invokable(selector)
     return invokable.invoke_3(receiver, arg1, arg2)
-
-
-def get_inline_cache_size(cache):
-    size = 0
-    while cache is not None:
-        size += 1
-        cache = cache.next_entry
-    return size

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -47,8 +47,7 @@ class BcAbstractMethod(AbstractMethod):
     _immutable_fields_ = [
         "_bytecodes?[*]",
         "_literals[*]",
-        "_inline_cache_layout",
-        "_inline_cache_invokable",
+        "_inline_cache",
         "_number_of_locals",
         "_maximum_number_of_stack_elements",
         "_number_of_arguments",
@@ -76,8 +75,7 @@ class BcAbstractMethod(AbstractMethod):
 
         # Set the number of bytecodes in this method
         self._bytecodes = ["\x00"] * num_bytecodes
-        self._inline_cache_layout = [None] * num_bytecodes
-        self._inline_cache_invokable = [None] * num_bytecodes
+        self._inline_cache = [None] * num_bytecodes
 
         self._literals = literals
 
@@ -148,18 +146,12 @@ class BcAbstractMethod(AbstractMethod):
         self._bytecodes[index] = chr(value)
 
     @jit.elidable
-    def get_inline_cache_layout(self, bytecode_index):
-        assert 0 <= bytecode_index < len(self._inline_cache_layout)
-        return self._inline_cache_layout[bytecode_index]
+    def get_inline_cache(self, bytecode_index):
+        assert 0 <= bytecode_index < len(self._inline_cache)
+        return self._inline_cache[bytecode_index]
 
-    @jit.elidable
-    def get_inline_cache_invokable(self, bytecode_index):
-        assert 0 <= bytecode_index < len(self._inline_cache_invokable)
-        return self._inline_cache_invokable[bytecode_index]
-
-    def set_inline_cache(self, bytecode_index, layout, invokable):
-        self._inline_cache_layout[bytecode_index] = layout
-        self._inline_cache_invokable[bytecode_index] = invokable
+    def set_inline_cache(self, bytecode_index, dispatch_node):
+        self._inline_cache[bytecode_index] = dispatch_node
 
     def patch_variable_access(self, bytecode_index):
         bc = self.get_bytecode(bytecode_index)

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -153,6 +153,23 @@ class BcAbstractMethod(AbstractMethod):
     def set_inline_cache(self, bytecode_index, dispatch_node):
         self._inline_cache[bytecode_index] = dispatch_node
 
+    def drop_old_inline_cache_entries(self, bytecode_index):
+        # Keep in sync with _AbstractGenericMessageNode._get_cache_size_and_drop_old_entries
+        prev = None
+        cache = self._inline_cache[bytecode_index]
+
+        while cache is not None:
+            if not cache.expected_layout.is_latest:
+                # drop old layout from cache
+                if prev is None:
+                    self._inline_cache[bytecode_index] = cache.next_entry
+                else:
+                    prev.next_entry = cache.next_entry
+            else:
+                prev = cache
+
+            cache = cache.next_entry
+
     def patch_variable_access(self, bytecode_index):
         bc = self.get_bytecode(bytecode_index)
         idx = self.get_bytecode(bytecode_index + 1)


### PR DESCRIPTION
Made the BC interpreter use the same inline caching strategy as the AST one, through relying on a `CachedDispatchNode` instead of the previous two lists for expected layout and invoke. This makes the max inline cache go from 2 to 8 (the value of INLINE_CACHE_SIZE, used in the AST interpreter)

This causes many minor slowdowns of around 2-4%, with some benchmarks (Mandelbrot, NBody) seemingly experiencing closer to 10% slowdowns. Some benchmarks seem to get a bit more performance out of it, around 2-5%