### PR TITLE
Document dump(), fix typing, fix GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
             id:   bc
             interp: BC
             python-version: pypy2.7
-          - name: Basics Python 2.7
-            python-version: 2.7
+          - name: Basics PyPy 2.7
+            python-version: pypy2.7
             id: basic
           - name: Basics Python 3.11
             python-version: 3.11

--- a/src/som/vm/universe.py
+++ b/src/som/vm/universe.py
@@ -488,7 +488,7 @@ def error_print(msg):
     os.write(2, encode_to_bytes(msg or ""))
 
 
-def error_println(msg=b""):
+def error_println(msg=""):
     os.write(2, encode_to_bytes(msg + "\n"))
 
 

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -46,9 +46,11 @@ def bgenc(cgenc, mgenc):
     return bgenc
 
 
-def method_to_bytecodes(mgenc, source):
+def method_to_bytecodes(mgenc, source, dump_bytecodes=False):
     parser = Parser(StringStream(source.strip()), "test", current_universe)
     parser.method(mgenc)
+    if dump_bytecodes:
+        dump(mgenc)
     return mgenc.get_bytecodes()
 
 

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -22,7 +22,7 @@ def add_field(cgenc, name):
 
 
 def dump(mgenc):
-    dump_method(mgenc, b"")
+    dump_method(mgenc, "")
 
 
 @pytest.fixture

--- a/tests/test_optimize_trivial.py
+++ b/tests/test_optimize_trivial.py
@@ -29,7 +29,7 @@ def add_field(cgenc, name):
 
 
 def dump(mgenc):
-    dump_method(mgenc, b"")
+    dump_method(mgenc, "")
 
 
 @pytest.fixture


### PR DESCRIPTION
`dump()` takes the method generation context. With this PR, `method_to_bytecodes()` also takes an optional `dump_bytecodes` argument to print the bytecodes after parsing.


/cc @naomiGrew @OctaveLarose I misremembered how to use `dump()` it needs the `mgenc`, not the bytecodes or the method. So, it already works as intended.
When the bytecodes are dumped, it gives output like the following:

```
(
<0 locals, 1 stack, 4 bc_count>
   0:PUSH_1  
   1:INC  
   2:POP  
   3:RETURN_SELF  
)
```
