### PR TITLE
Fix Shell on Python 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
           SOM_INTERP=BC  pytest
           SOM_INTERP=AST ./som.sh -cp Smalltalk TestSuite/TestHarness.som
           SOM_INTERP=BC  ./som.sh -cp Smalltalk TestSuite/TestHarness.som
+          echo "[system exit: 0] value" | SOM_INTERP=AST ./som.sh -cp Smalltalk
+          echo "[system exit: 0] value" | SOM_INTERP=BC  ./som.sh -cp Smalltalk
 
       - name: Full Tests
         if: matrix.id != 'basic'

--- a/src/rlib/osext.py
+++ b/src/rlib/osext.py
@@ -23,7 +23,7 @@ def path_split(path):
 
 
 def _read_raw(answer):
-    buf = os.read(1, 32)
+    buf = os.read(0, 32)
     if len(buf) == 0:
         return answer, False
     if buf[-1] == b"\n"[0]:

--- a/src/rlib/osext.py
+++ b/src/rlib/osext.py
@@ -1,5 +1,7 @@
 import os
 
+from rlib.string_stream import decode_str
+
 
 def path_split(path):
     """
@@ -25,8 +27,8 @@ def _read_raw(answer):
     if len(buf) == 0:
         return answer, False
     if buf[-1] == b"\n"[0]:
-        return answer + buf[:-1].decode('utf8'), False
-    return answer + buf.decode('utf8'), True
+        return answer + decode_str(buf[:-1]), False
+    return answer + decode_str(buf), True
 
 
 def raw_input(msg=b""):

--- a/src/rlib/osext.py
+++ b/src/rlib/osext.py
@@ -24,12 +24,12 @@ def _read_raw(answer):
     buf = os.read(1, 32)
     if len(buf) == 0:
         return answer, False
-    if buf[-1] == "\n":
-        return answer + buf[:-1], False
-    return answer + buf, True
+    if buf[-1] == b"\n"[0]:
+        return answer + buf[:-1].decode('utf8'), False
+    return answer + buf.decode('utf8'), True
 
 
-def raw_input(msg=""):
+def raw_input(msg=b""):
     os.write(1, msg)
     answer, cont = _read_raw("")
     while cont:

--- a/src/rlib/string_stream.py
+++ b/src/rlib/string_stream.py
@@ -4,6 +4,9 @@ try:
     def encode_to_bytes(str_value):
         return str_value
 
+    def decode_str(str_value):
+        return str_value
+
 except ImportError:
     "NOT_RPYTHON"
 
@@ -20,9 +23,15 @@ except ImportError:
         def encode_to_bytes(str_value):
             return str_value.encode("utf-8")
 
+        def decode_str(str_value):
+            return str_value.decode("utf-8")
+
     else:
 
         def encode_to_bytes(str_value):
+            return str_value
+
+        def decode_str(str_value):
             return str_value
 
 

--- a/src/som/vm/shell.py
+++ b/src/som/vm/shell.py
@@ -1,3 +1,4 @@
+from rlib.exit import Exit
 from rlib.objectmodel import we_are_translated
 from rlib.osext import raw_input
 from som.compiler.parse_error import ParseError
@@ -47,6 +48,8 @@ class Shell(object):
                     it = shell_method.invoke_2(shell_object, it)
             except ParseError as ex:
                 error_println(str(ex))
+            except Exit as ex:
+                raise ex
             except Exception as ex:  # pylint: disable=broad-except
                 if not we_are_translated():  # this cannot be done in rpython
                     import traceback

--- a/src/som/vm/shell.py
+++ b/src/som/vm/shell.py
@@ -1,5 +1,6 @@
 from rlib.objectmodel import we_are_translated
 from rlib.osext import raw_input
+from som.compiler.parse_error import ParseError
 from som.vm.globals import nilObject
 from som.vm.symbols import symbol_for
 
@@ -19,7 +20,7 @@ class Shell(object):
         while True:
             try:
                 # Read a statement from the keyboard
-                stmt = raw_input("---> ")
+                stmt = raw_input(b"---> ")
                 if stmt == "quit" or stmt == "":
                     return it
                 if stmt == "\n":
@@ -44,6 +45,8 @@ class Shell(object):
                     shell_method = shell_class.lookup_invokable(symbol_for("run:"))
 
                     it = shell_method.invoke_2(shell_object, it)
+            except ParseError as ex:
+                error_println(str(ex))
             except Exception as ex:  # pylint: disable=broad-except
                 if not we_are_translated():  # this cannot be done in rpython
                     import traceback


### PR DESCRIPTION
As reported by @naomiGrew, the shell on Python 3 had issues with type confusion for the reading/writing to the terminal.

It resulted in an endless loop of the following output:

```python
TypeError: a bytes-like object is required, not 'str'
Caught exception: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/Users/smarr/Projects/SOM/PySOM/src/som/vm/shell.py", line 23, in start
    stmt = raw_input("---> ")
           ^^^^^^^^^^^^^^^^^^
  File "/Users/smarr/Projects/SOM/PySOM/src/rlib/osext.py", line 33, in raw_input
    os.write(1, msg)
TypeError: a bytes-like object is required, not 'str'
```

This PR fixes it, and also adds special handling for `ParseError`s and `Exit` in the shell to avoid printing the traceback for them.

/cc @naomiGrew @OctaveLarose
