### PR TITLE
Update core-lib and RPython

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,19 +26,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Set up PyPy
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download PyPy Sources
         if: matrix.id != 'basic'
         run: |
-          export PYPYVER=v7.3.11
+          export PYPYVER=v7.3.15
           curl https://downloads.python.org/pypy/pypy2.7-${PYPYVER}-src.tar.bz2 -o pypy.tar.bz2
           tar -xjf pypy.tar.bz2
           mv pypy2.7-${PYPYVER}-src .pypy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,8 @@ stages:
 
 variables:
   PYTHONUNBUFFERED: "true"
-  PYPY_SRC_DIR: /home/gitlab-runner/.local/pypy2.7-v7.3.11-src
-  PYPY_BIN_DIR: /home/gitlab-runner/.local/pypy2.7-v7.3.11-linux64/bin
+  PYPY_SRC_DIR: /data/home/gitlab-runner/.asdf/installs/awfy/pypysrc-2.7-v7.3.15
+  PYPY_BIN_DIR: /data/home/gitlab-runner/.asdf/installs/python/pypy2.7-7.3.15/bin
 
 before_script:
   - git submodule update --init

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,8 @@ build-and-test-interpreters:
     - export PATH=$PATH:$PYPY_BIN_DIR
 
     - export SOM_INTERP=BC
-    
+    - (cd Examples/Benchmarks/TestSuite && ./duplicate-tests.sh)
+
     # Unit Tests
     - PYTHONPATH=src python3 -m pytest
     - ./som.sh -cp Smalltalk TestSuite/TestHarness.som
@@ -30,6 +31,7 @@ build-and-test-interpreters:
     # Interpreter
     - $RPYTHON --batch src/main_rpython.py
     - ./som-bc-interp -cp Smalltalk TestSuite/TestHarness.som
+    - ./som-bc-interp -cp Smalltalk:TestSuite Examples/Benchmarks/TestSuite/TestTestSuite.som
 
     - export SOM_INTERP=AST
     
@@ -40,6 +42,7 @@ build-and-test-interpreters:
     # Interpreter
     - $RPYTHON --batch src/main_rpython.py
     - ./som-ast-interp -cp Smalltalk TestSuite/TestHarness.som
+    - ./som-ast-interp -cp Smalltalk:TestSuite Examples/Benchmarks/TestSuite/TestTestSuite.som
 
 
     # Package and Upload
@@ -67,6 +70,8 @@ build-and-test-jit-bc:
     # JIT Compiled Version
     - $RPYTHON --batch -Ojit src/main_rpython.py
     - ./som-bc-jit -cp Smalltalk TestSuite/TestHarness.som
+    - (cd Examples/Benchmarks/TestSuite && ./duplicate-tests.sh)
+    - ./som-bc-jit -cp Smalltalk:TestSuite Examples/Benchmarks/TestSuite/TestTestSuite.som
 
     # Package and Upload
     - lz4 som-bc-jit som-bc-jit.lz4
@@ -91,6 +96,8 @@ build-and-test-jit-ast:
     # JIT Compiled Version
     - $RPYTHON --batch -Ojit src/main_rpython.py
     - ./som-ast-jit -cp Smalltalk TestSuite/TestHarness.som
+    - (cd Examples/Benchmarks/TestSuite && ./duplicate-tests.sh)
+    - ./som-ast-jit -cp Smalltalk:TestSuite Examples/Benchmarks/TestSuite/TestTestSuite.som
 
     # Package and Upload
     - lz4 som-ast-jit som-ast-jit.lz4

--- a/src/som/compiler/bc/method_generation_context.py
+++ b/src/som/compiler/bc/method_generation_context.py
@@ -276,8 +276,7 @@ class MethodGenerationContext(MethodGenerationContextBase):
 
     def add_bytecode(self, bytecode, stack_effect):
         self._current_stack_depth += stack_effect
-        if self._current_stack_depth > self.max_stack_depth:
-            self.max_stack_depth = self._current_stack_depth
+        self.max_stack_depth = max(self.max_stack_depth, self._current_stack_depth)
 
         self._bytecode.append(bytecode)
         self._last_4_bytecodes[0] = self._last_4_bytecodes[1]

--- a/src/som/compiler/parser.py
+++ b/src/som/compiler/parser.py
@@ -299,7 +299,7 @@ class ParserBase(object):
 
             bigint = bigint_from_str(self._text)
             if negate_value:
-                bigint.sign = -1
+                bigint._set_sign(-1)  # pylint: disable=protected-access
             result = BigInteger(bigint)
         except ValueError:
             raise ParseError(

--- a/src/som/vmobjects/object_with_layout.py
+++ b/src/som/vmobjects/object_with_layout.py
@@ -64,12 +64,12 @@ class Object(ObjectWithoutFields):
 
     def _set_all_fields(self, field_values):
         assert not we_are_jitted()
-        self._field1 = (
-            self._field2
-        ) = self._field3 = self._field4 = self._field5 = nilObject
-        self.prim_field1 = (
-            self.prim_field2
-        ) = self.prim_field3 = self.prim_field4 = self.prim_field5 = 1234567890
+        self._field1 = self._field2 = self._field3 = self._field4 = self._field5 = (
+            nilObject
+        )
+        self.prim_field1 = self.prim_field2 = self.prim_field3 = self.prim_field4 = (
+            self.prim_field5
+        ) = 1234567890
 
         for i in range(0, self._object_layout.get_number_of_fields()):
             if field_values[i] is None:


### PR DESCRIPTION
This PR updates RPython/PyPy to 7.3.15, which required a fix of setting the sign on RPython's bitint objects differently.

We also:
 - fix some formatting issues with new Black versions
 - update the core-lib to be able to test the unittest benchmark
 - fix some lint warnings