### PR TITLE
At primitive implementation for String>>#charAt:

### DIFF
--- a/src/som/interpreter/ast/frame.py
+++ b/src/som/interpreter/ast/frame.py
@@ -46,9 +46,9 @@ from som.vm.globals import nilObject, trueObject, falseObject
 #   Inner
 #
 #  +-----------------+
-#  | OnStack         |
+#  | OnStack         |  boolean indicating whether the frame is still on the stack
 #  +-----------------+
-#  | Receiver        |
+#  | Receiver        |  the same as the receiver in the frame, not to be changed
 #  +-----------------+
 #  | ArgForInner 1   |
 #  | ...             |

--- a/src/som/interpreter/bc/frame.py
+++ b/src/som/interpreter/bc/frame.py
@@ -32,6 +32,22 @@ from som.interpreter.ast.frame import (
 #  | ...       |
 #  | Local n   |
 #  +-----------+
+#
+#   Inner
+#
+#  +-----------------+
+#  | OnStack         |  boolean indicating whether the frame is still on the stack
+#  +-----------------+
+#  | Receiver        |  the same as the receiver in the frame, not to be changed
+#  +-----------------+
+#  | ArgForInner 1   |
+#  | ...             |
+#  | ArgForInner n   |
+#  +-----------------+
+#  | LocalForInner 1 |
+#  | ...             |
+#  | LocalForInner n |
+#  +-----------------+
 
 
 def create_frame(

--- a/src/som/primitives/string_primitives.py
+++ b/src/som/primitives/string_primitives.py
@@ -39,6 +39,15 @@ def _substring(rcvr, start, end):
     return String(string[s:e])
 
 
+def _char_at(rcvr, idx):
+    i = idx.get_embedded_integer() - 1
+    string = rcvr.get_embedded_string()
+
+    if i < 0 or i >= len(string):
+        return String("Error - index out of bounds")
+    return String(string[i])
+
+
 def _hashcode(rcvr):
     return Integer(compute_hash(rcvr.get_embedded_string()))
 
@@ -81,6 +90,7 @@ def _is_digits(self):
 
 class StringPrimitivesBase(Primitives):
     def install_primitives(self):
+        self._install_instance_primitive(BinaryPrimitive("charAt:", _char_at))
         self._install_instance_primitive(BinaryPrimitive("concatenate:", _concat))
         self._install_instance_primitive(UnaryPrimitive("asSymbol", _as_symbol))
         self._install_instance_primitive(UnaryPrimitive("length", _length))


### PR DESCRIPTION
This gives a good speedup in the interpreters for Json, the only benchmark using it.

The bytecode JIT startup seems to suffer unfortunately. I assume it's some odd interaction.
BC JIT steady performance also improves quite a bit.

The AST JIT is not bothered, neither for startup nor steady performance.

https://rebench.dev/RPySOM/compare/470bab233c9f2bc9f97362be394b298301f66ecc..d93c8ba6588b2a5d3d81ef40d16a000840f83cca

The PR also adds the diagram describing the inner frame, from the AST interpreter to the BC one. I am pretty sure its correct, but didn't check... I know, future me will hate this...