### PR TITLE
Add more interpreter microbenchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ before_script:
 build:aarch64-test-and-rebench:
   stage: build-test
   tags: [zullie1]
-  
+
   script:
     - export PATH=/opt/local/bin:/opt/local/sbin:/Users/gitlab-runner/Library/Python/3.12/bin:${PATH}:${PYPY_BIN_DIR}
 
@@ -43,10 +43,9 @@ build:aarch64-test-and-rebench:
     - SOM_INTERP=AST $RPYTHON --batch src/main_rpython.py
     - ./som-ast-interp -cp Smalltalk TestSuite/TestHarness.som
     - ./som-ast-interp -cp Smalltalk:TestSuite Examples/Benchmarks/TestSuite/TestTestSuite.som
-    
-    - (cd Examples/Benchmarks/TestSuite && ./duplicate-tests.sh)  
+
+    - (cd Examples/Benchmarks/TestSuite && ./duplicate-tests.sh)
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --branch="$CI_COMMIT_REF_NAME" -c rebench.conf
-    
 
 build-and-test-interpreters:
   stage: build-test
@@ -66,21 +65,20 @@ build-and-test-interpreters:
     - ./som-bc-interp -cp Smalltalk:TestSuite Examples/Benchmarks/TestSuite/TestTestSuite.som
 
     - export SOM_INTERP=AST
-    
+
     # Unit Tests
     - PYTHONPATH=src python3 -m pytest
     - ./som.sh -cp Smalltalk TestSuite/TestHarness.som
-    
+
     # Interpreter
     - $RPYTHON --batch src/main_rpython.py
     - ./som-ast-interp -cp Smalltalk TestSuite/TestHarness.som
     - ./som-ast-interp -cp Smalltalk:TestSuite Examples/Benchmarks/TestSuite/TestTestSuite.som
 
-
     # Package and Upload
     - lz4 som-ast-interp som-ast-interp.lz4
     - lz4 som-bc-interp  som-bc-interp.lz4
-    
+
     - |
       sftp tmp-artifacts << EOF
         -mkdir incoming/${CI_PIPELINE_ID}/
@@ -94,7 +92,7 @@ build-and-test-jit-bc:
   script:
     - export PATH=$PATH:$PYPY_BIN_DIR
     - export SOM_INTERP=BC
-    
+
     # JIT Compiled Version
     - $RPYTHON --batch -Ojit src/main_rpython.py
     - ./som-bc-jit -cp Smalltalk TestSuite/TestHarness.som
@@ -103,7 +101,7 @@ build-and-test-jit-bc:
 
     # Package and Upload
     - lz4 som-bc-jit som-bc-jit.lz4
-    
+
     - |
       sftp tmp-artifacts << EOF
         -mkdir incoming/${CI_PIPELINE_ID}/
@@ -116,7 +114,7 @@ build-and-test-jit-ast:
   script:
     - export PATH=$PATH:$PYPY_BIN_DIR
     - export SOM_INTERP=AST
-    
+
     # JIT Compiled Version
     - $RPYTHON --batch -Ojit src/main_rpython.py
     - ./som-ast-jit -cp Smalltalk TestSuite/TestHarness.som
@@ -125,7 +123,7 @@ build-and-test-jit-ast:
 
     # Package and Upload
     - lz4 som-ast-jit som-ast-jit.lz4
-    
+
     - |
       sftp tmp-artifacts << EOF
         -mkdir incoming/${CI_PIPELINE_ID}/
@@ -134,13 +132,15 @@ build-and-test-jit-ast:
 
 benchmark-y1:
   stage: benchmark
+  needs:
+    [build-and-test-interpreters, build-and-test-jit-bc, build-and-test-jit-ast]
   tags: [yuria]
   script:
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-jit.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-interp.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-jit.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-interp.lz4
-    
+
     - lz4 -d som-ast-jit.lz4    som-ast-jit
     - lz4 -d som-ast-interp.lz4 som-ast-interp
     - lz4 -d som-bc-jit.lz4     som-bc-jit
@@ -151,13 +151,15 @@ benchmark-y1:
 
 benchmark-y2:
   stage: benchmark
+  needs:
+    [build-and-test-interpreters, build-and-test-jit-bc, build-and-test-jit-ast]
   tags: [yuria2]
   script:
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-jit.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-interp.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-jit.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-interp.lz4
-    
+
     - lz4 -d som-ast-jit.lz4    som-ast-jit
     - lz4 -d som-ast-interp.lz4 som-ast-interp
     - lz4 -d som-bc-jit.lz4     som-bc-jit
@@ -168,13 +170,15 @@ benchmark-y2:
 
 benchmark-y3:
   stage: benchmark
+  needs:
+    [build-and-test-interpreters, build-and-test-jit-bc, build-and-test-jit-ast]
   tags: [yuria3]
   script:
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-jit.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-ast-interp.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-jit.lz4
     - sftp tmp-artifacts:incoming/${CI_PIPELINE_ID}/som-bc-interp.lz4
-    
+
     - lz4 -d som-ast-jit.lz4    som-ast-jit
     - lz4 -d som-ast-interp.lz4 som-ast-interp
     - lz4 -d som-bc-jit.lz4     som-bc-jit
@@ -185,6 +189,8 @@ benchmark-y3:
 
 report-completion:
   stage: benchmark-completion
+  needs:
+    [benchmark-y1, benchmark-y2, benchmark-y3, build:aarch64-test-and-rebench]
   tags: [yuria]
   script:
     - rebench --experiment="CI ID $CI_PIPELINE_ID" --report-completion rebench.conf

--- a/rebench.conf
+++ b/rebench.conf
@@ -132,6 +132,28 @@ benchmark_suites:
             - SomParse: {extra_args: 1, machines: [yuria2]}
             - SomInit:  {extra_args: 10000, machines: [yuria2]}
 
+    interpreter:
+        description: Basic interpreter benchmarks for comparing performance of most basic concepts.
+        gauge_adapter: RebenchLog
+        command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 1"
+        benchmarks:
+            - ArgRead
+            - ArrayReadConst
+            - ArrayWriteConstConst
+            - BlockSend0ConstReturn
+            - Const
+            - FieldConstWrite
+            - FieldRead
+            - FieldReadIncWrite
+            - FieldReadWrite
+            - GlobalRead
+            - LocalConstWrite
+            - LocalRead
+            - LocalReadIncWrite
+            - LocalReadWrite
+            - SelfSend0
+            - SelfSend0BlockConstNonLocalReturn
+
 executors:
     RPySOM-ast-interp:
         path: .
@@ -167,12 +189,14 @@ experiments:
                     - macro-startup
                     - awfy-startup
                     - som-parse
+                    - interpreter
             - RPySOM-bc-interp:
                 suites:
                     - micro-startup
                     - macro-startup
                     - awfy-startup
                     - som-parse
+                    - interpreter
             - RPySOM-ast-jit:
                 suites:
                     - micro-startup

--- a/rebench.conf
+++ b/rebench.conf
@@ -135,24 +135,25 @@ benchmark_suites:
     interpreter:
         description: Basic interpreter benchmarks for comparing performance of most basic concepts.
         gauge_adapter: RebenchLog
+        invocations: 5
         command: "-cp Smalltalk:Examples/Benchmarks/Interpreter Examples/Benchmarks/BenchmarkHarness.som %(benchmark)s %(iterations)s 1"
         benchmarks:
-            - ArgRead
-            - ArrayReadConst
-            - ArrayWriteConstConst
-            - BlockSend0ConstReturn
-            - Const
-            - FieldConstWrite
-            - FieldRead
-            - FieldReadIncWrite
-            - FieldReadWrite
-            - GlobalRead
-            - LocalConstWrite
-            - LocalRead
-            - LocalReadIncWrite
-            - LocalReadWrite
-            - SelfSend0
-            - SelfSend0BlockConstNonLocalReturn
+            - ArgRead:                           {machines: [yuria ]}
+            - ArrayReadConst:                    {machines: [yuria ]}
+            - ArrayWriteConstConst:              {machines: [yuria ]}
+            - BlockSend0ConstReturn:             {machines: [yuria ]}
+            - Const:                             {machines: [yuria ]}
+            - FieldConstWrite:                   {machines: [yuria ]}
+            - FieldRead:                         {machines: [yuria ]}
+            - FieldReadIncWrite:                 {machines: [yuria ]}
+            - FieldReadWrite:                    {machines: [yuria ]}
+            - GlobalRead:                        {machines: [yuria ]}
+            - LocalConstWrite:                   {machines: [yuria ]}
+            - LocalRead:                         {machines: [yuria ]}
+            - LocalReadIncWrite:                 {machines: [yuria ]}
+            - LocalReadWrite:                    {machines: [yuria ]}
+            - SelfSend0:                         {machines: [yuria ]}
+            - SelfSend0BlockConstNonLocalReturn: {machines: [yuria ]}
 
 executors:
     RPySOM-ast-interp:


### PR DESCRIPTION
This updates the core-lib to https://github.com/SOM-st/SOM/pull/121
and adds the benchmarks to the rebench.conf file.