### PR TITLE
Add inlining for `#ifNil:*` variants

### DIFF
--- a/src/som/interpreter/ast/nodes/specialized/literal_if.py
+++ b/src/som/interpreter/ast/nodes/specialized/literal_if.py
@@ -31,6 +31,46 @@ class IfInlinedNode(ExpressionNode):
         )
 
 
+class IfNilInlinedNode(ExpressionNode):
+    _immutable_fields_ = [
+        "_condition_expr?",
+        "_body_expr?",
+        "universe",
+    ]
+    _child_nodes_ = ["_condition_expr", "_body_expr"]
+
+    def __init__(self, condition_expr, body_expr, source_section):
+        ExpressionNode.__init__(self, source_section)
+        self._condition_expr = self.adopt_child(condition_expr)
+        self._body_expr = self.adopt_child(body_expr)
+
+    def execute(self, frame):
+        result = self._condition_expr.execute(frame)
+        if result is nilObject:
+            return self._body_expr.execute(frame)
+        return result
+
+
+class IfNotNilInlinedNode(ExpressionNode):
+    _immutable_fields_ = [
+        "_condition_expr?",
+        "_body_expr?",
+        "universe",
+    ]
+    _child_nodes_ = ["_condition_expr", "_body_expr"]
+
+    def __init__(self, condition_expr, body_expr, source_section):
+        ExpressionNode.__init__(self, source_section)
+        self._condition_expr = self.adopt_child(condition_expr)
+        self._body_expr = self.adopt_child(body_expr)
+
+    def execute(self, frame):
+        result = self._condition_expr.execute(frame)
+        if result is nilObject:
+            return result
+        return self._body_expr.execute(frame)
+
+
 class IfElseInlinedNode(ExpressionNode):
     _immutable_fields_ = [
         "_condition_expr?",
@@ -61,3 +101,25 @@ class IfElseInlinedNode(ExpressionNode):
             "Would need to generalize, but we haven't implemented that "
             + "for the bytecode interpreter either"
         )
+
+
+class IfNilNotNilInlinedNode(ExpressionNode):
+    _immutable_fields_ = [
+        "_condition_expr?",
+        "_nil_expr?",
+        "_not_nil_expr?",
+        "universe",
+    ]
+    _child_nodes_ = ["_condition_expr", "_nil_expr", "_not_nil_expr"]
+
+    def __init__(self, condition_expr, nil_expr, not_nil_expr, source_section):
+        ExpressionNode.__init__(self, source_section)
+        self._condition_expr = self.adopt_child(condition_expr)
+        self._nil_expr = self.adopt_child(nil_expr)
+        self._not_nil_expr = self.adopt_child(not_nil_expr)
+
+    def execute(self, frame):
+        result = self._condition_expr.execute(frame)
+        if result is nilObject:
+            return self._nil_expr.execute(frame)
+        return self._not_nil_expr.execute(frame)

--- a/src/som/interpreter/bc/bytecodes.py
+++ b/src/som/interpreter/bc/bytecodes.py
@@ -80,13 +80,21 @@ class Bytecodes(object):
     jump_on_false_top_nil = jump_on_true_top_nil + 1
     jump_on_true_pop = jump_on_false_top_nil + 1
     jump_on_false_pop = jump_on_true_pop + 1
-    jump_backward = jump_on_false_pop + 1
+    jump_on_not_nil_top_top = jump_on_false_pop + 1
+    jump_on_nil_top_top = jump_on_not_nil_top_top + 1
+    jump_on_not_nil_pop = jump_on_nil_top_top + 1
+    jump_on_nil_pop = jump_on_not_nil_pop + 1
+    jump_backward = jump_on_nil_pop + 1
     jump2 = jump_backward + 1
     jump2_on_true_top_nil = jump2 + 1
     jump2_on_false_top_nil = jump2_on_true_top_nil + 1
     jump2_on_true_pop = jump2_on_false_top_nil + 1
     jump2_on_false_pop = jump2_on_true_pop + 1
-    jump2_backward = jump2_on_false_pop + 1
+    jump2_on_not_nil_top_top = jump2_on_false_pop + 1
+    jump2_on_nil_top_top = jump2_on_not_nil_top_top + 1
+    jump2_on_not_nil_pop = jump2_on_nil_top_top + 1
+    jump2_on_nil_pop = jump2_on_not_nil_pop + 1
+    jump2_backward = jump2_on_nil_pop + 1
 
     q_super_send_1 = jump2_backward + 1
     q_super_send_2 = q_super_send_1 + 1
@@ -154,12 +162,20 @@ JUMP_BYTECODES = [
     Bytecodes.jump_on_true_pop,
     Bytecodes.jump_on_false_pop,
     Bytecodes.jump_on_false_top_nil,
+    Bytecodes.jump_on_not_nil_top_top,
+    Bytecodes.jump_on_nil_top_top,
+    Bytecodes.jump_on_not_nil_pop,
+    Bytecodes.jump_on_nil_pop,
     Bytecodes.jump_backward,
     Bytecodes.jump2,
     Bytecodes.jump2_on_true_top_nil,
     Bytecodes.jump2_on_true_pop,
     Bytecodes.jump2_on_false_pop,
     Bytecodes.jump2_on_false_top_nil,
+    Bytecodes.jump2_on_not_nil_top_top,
+    Bytecodes.jump2_on_nil_top_top,
+    Bytecodes.jump2_on_not_nil_pop,
+    Bytecodes.jump2_on_nil_pop,
     Bytecodes.jump2_backward,
 ]
 
@@ -258,12 +274,20 @@ _BYTECODE_LENGTH = [
     LEN_TWO_ARGS,  # jump_on_false_top_nil
     LEN_TWO_ARGS,  # jump_on_true_pop
     LEN_TWO_ARGS,  # jump_on_false_pop
+    LEN_TWO_ARGS,  # jump_on_not_nil_top_top,
+    LEN_TWO_ARGS,  # jump_on_nil_top_top,
+    LEN_TWO_ARGS,  # jump_on_not_nil_pop,
+    LEN_TWO_ARGS,  # jump_on_nil_pop,
     LEN_TWO_ARGS,  # jump_backward
     LEN_TWO_ARGS,  # jump2
     LEN_TWO_ARGS,  # jump2_on_true_top_nil
     LEN_TWO_ARGS,  # jump2_on_false_top_nil
     LEN_TWO_ARGS,  # jump2_on_true_pop
     LEN_TWO_ARGS,  # jump2_on_false_pop
+    LEN_TWO_ARGS,  # jump2_on_not_nil_top_top,
+    LEN_TWO_ARGS,  # jump2_on_nil_top_top,
+    LEN_TWO_ARGS,  # jump2_on_not_nil_pop,
+    LEN_TWO_ARGS,  # jump2_on_nil_pop,
     LEN_TWO_ARGS,  # jump2_backward
     LEN_ONE_ARG,  # q_super_send_1
     LEN_ONE_ARG,  # q_super_send_2

--- a/src/som/interpreter/bc/interpreter.py
+++ b/src/som/interpreter/bc/interpreter.py
@@ -584,6 +584,48 @@ def interpret(method, frame, max_stack_size):
                 stack[stack_ptr] = None
             stack_ptr -= 1
 
+        elif bytecode == Bytecodes.jump_on_not_nil_top_top:
+            val = stack[stack_ptr]
+            if val is not nilObject:
+                current_bc_idx += method.get_bytecode(current_bc_idx + 1)
+                # stack[stack_ptr] = val
+            else:
+                if we_are_jitted():
+                    stack[stack_ptr] = None
+                stack_ptr -= 1
+                current_bc_idx += LEN_TWO_ARGS
+
+        elif bytecode == Bytecodes.jump_on_nil_top_top:
+            val = stack[stack_ptr]
+            if val is nilObject:
+                current_bc_idx += method.get_bytecode(current_bc_idx + 1)
+                # stack[stack_ptr] = val
+            else:
+                if we_are_jitted():
+                    stack[stack_ptr] = None
+                stack_ptr -= 1
+                current_bc_idx += LEN_TWO_ARGS
+
+        elif bytecode == Bytecodes.jump_on_not_nil_pop:
+            val = stack[stack_ptr]
+            if val is not nilObject:
+                current_bc_idx += method.get_bytecode(current_bc_idx + 1)
+            else:
+                current_bc_idx += LEN_TWO_ARGS
+            if we_are_jitted():
+                stack[stack_ptr] = None
+            stack_ptr -= 1
+
+        elif bytecode == Bytecodes.jump_on_nil_pop:
+            val = stack[stack_ptr]
+            if val is nilObject:
+                current_bc_idx += method.get_bytecode(current_bc_idx + 1)
+            else:
+                current_bc_idx += LEN_TWO_ARGS
+            if we_are_jitted():
+                stack[stack_ptr] = None
+            stack_ptr -= 1
+
         elif bytecode == Bytecodes.jump_backward:
             current_bc_idx -= method.get_bytecode(current_bc_idx + 1)
             jitdriver.can_enter_jit(
@@ -649,6 +691,55 @@ def interpret(method, frame, max_stack_size):
                 stack[stack_ptr] = None
             stack_ptr -= 1
 
+        elif bytecode == Bytecodes.jump2_on_not_nil_top_top:
+            val = stack[stack_ptr]
+            if val is not nilObject:
+                current_bc_idx += method.get_bytecode(current_bc_idx + 1) + (
+                    method.get_bytecode(current_bc_idx + 2) << 8
+                )
+                # stack[stack_ptr] = val
+            else:
+                if we_are_jitted():
+                    stack[stack_ptr] = None
+                stack_ptr -= 1
+                current_bc_idx += LEN_TWO_ARGS
+
+        elif bytecode == Bytecodes.jump2_on_nil_top_top:
+            val = stack[stack_ptr]
+            if val is nilObject:
+                current_bc_idx += method.get_bytecode(current_bc_idx + 1) + (
+                    method.get_bytecode(current_bc_idx + 2) << 8
+                )
+                # stack[stack_ptr] = val
+            else:
+                if we_are_jitted():
+                    stack[stack_ptr] = None
+                stack_ptr -= 1
+                current_bc_idx += LEN_TWO_ARGS
+
+        elif bytecode == Bytecodes.jump2_on_not_nil_pop:
+            val = stack[stack_ptr]
+            if val is not nilObject:
+                current_bc_idx += method.get_bytecode(current_bc_idx + 1) + (
+                    method.get_bytecode(current_bc_idx + 2) << 8
+                )
+            else:
+                current_bc_idx += LEN_TWO_ARGS
+            if we_are_jitted():
+                stack[stack_ptr] = None
+            stack_ptr -= 1
+
+        elif bytecode == Bytecodes.jump2_on_nil_pop:
+            val = stack[stack_ptr]
+            if val is nilObject:
+                current_bc_idx += method.get_bytecode(current_bc_idx + 1) + (
+                    method.get_bytecode(current_bc_idx + 2) << 8
+                )
+            else:
+                current_bc_idx += LEN_TWO_ARGS
+            if we_are_jitted():
+                stack[stack_ptr] = None
+            stack_ptr -= 1
         elif bytecode == Bytecodes.jump2_backward:
             current_bc_idx -= method.get_bytecode(current_bc_idx + 1) + (
                 method.get_bytecode(current_bc_idx + 2) << 8

--- a/src/som/vmobjects/method_bc.py
+++ b/src/som/vmobjects/method_bc.py
@@ -434,9 +434,13 @@ class BcMethod(BcAbstractMethod):
                 bytecode == Bytecodes.jump
                 or bytecode == Bytecodes.jump_on_true_top_nil
                 or bytecode == Bytecodes.jump_on_false_top_nil
+                or bytecode == Bytecodes.jump_on_not_nil_top_top
+                or bytecode == Bytecodes.jump_on_nil_top_top
                 or bytecode == Bytecodes.jump2
                 or bytecode == Bytecodes.jump2_on_true_top_nil
                 or bytecode == Bytecodes.jump2_on_false_top_nil
+                or bytecode == Bytecodes.jump2_on_not_nil_top_top
+                or bytecode == Bytecodes.jump2_on_nil_top_top
             ):
                 # emit the jump, but instead of the offset, emit a dummy
                 idx = emit3_with_dummy(mgenc, bytecode, 0)
@@ -448,8 +452,12 @@ class BcMethod(BcAbstractMethod):
             elif (
                 bytecode == Bytecodes.jump_on_true_pop
                 or bytecode == Bytecodes.jump_on_false_pop
+                or bytecode == Bytecodes.jump_on_not_nil_pop
+                or bytecode == Bytecodes.jump_on_nil_pop
                 or bytecode == Bytecodes.jump2_on_true_pop
                 or bytecode == Bytecodes.jump2_on_false_pop
+                or bytecode == Bytecodes.jump2_on_not_nil_pop
+                or bytecode == Bytecodes.jump2_on_nil_pop
             ):
                 # emit the jump, but instead of the offset, emit a dummy
                 idx = emit3_with_dummy(mgenc, bytecode, -1)
@@ -529,12 +537,20 @@ class BcMethod(BcAbstractMethod):
                 or bytecode == Bytecodes.jump_on_true_pop
                 or bytecode == Bytecodes.jump_on_false_top_nil
                 or bytecode == Bytecodes.jump_on_false_pop
+                or bytecode == Bytecodes.jump_on_not_nil_top_top
+                or bytecode == Bytecodes.jump_on_nil_top_top
+                or bytecode == Bytecodes.jump_on_not_nil_pop
+                or bytecode == Bytecodes.jump_on_nil_pop
                 or bytecode == Bytecodes.jump_backward
                 or bytecode == Bytecodes.jump2
                 or bytecode == Bytecodes.jump2_on_true_top_nil
                 or bytecode == Bytecodes.jump2_on_true_pop
                 or bytecode == Bytecodes.jump2_on_false_top_nil
                 or bytecode == Bytecodes.jump2_on_false_pop
+                or bytecode == Bytecodes.jump2_on_not_nil_top_top
+                or bytecode == Bytecodes.jump2_on_nil_top_top
+                or bytecode == Bytecodes.jump2_on_not_nil_pop
+                or bytecode == Bytecodes.jump2_on_nil_pop
                 or bytecode == Bytecodes.jump2_backward
             ):
                 # don't use context

--- a/tests/test_bytecode_generation.py
+++ b/tests/test_bytecode_generation.py
@@ -360,6 +360,8 @@ def test_if_true_with_something_and_literal_return(mgenc, literal, bytecode):
     [
         ("ifTrue:", Bytecodes.jump_on_false_top_nil),
         ("ifFalse:", Bytecodes.jump_on_true_top_nil),
+        ("ifNil:", Bytecodes.jump_on_not_nil_top_top),
+        ("ifNotNil:", Bytecodes.jump_on_nil_top_top),
     ],
 )
 def test_if_arg(mgenc, if_selector, jump_bytecode):
@@ -792,6 +794,8 @@ def test_if_true_if_false_nlr_arg2(mgenc):
     [
         ("ifTrue:", "ifFalse:", Bytecodes.jump_on_false_pop),
         ("ifFalse:", "ifTrue:", Bytecodes.jump_on_true_pop),
+        ("ifNil:", "ifNotNil:", Bytecodes.jump_on_not_nil_pop),
+        ("ifNotNil:", "ifNil:", Bytecodes.jump_on_nil_pop),
     ],
 )
 def test_if_true_if_false_return(mgenc, sel1, sel2, jump_bytecode):


### PR DESCRIPTION
This adds the inlining of the various `#ifNil:` selectors to both the AST and the bytecode interpreter.