### PR TITLE
Update core-lib and add benchmarks to rebench.conf

### DIFF
--- a/rebench.conf
+++ b/rebench.conf
@@ -84,6 +84,8 @@ benchmark_suites:
             - WhileLoop:    {extra_args:  30, tags: [yuria ]}
             - Mandelbrot:   {extra_args:  50, tags: [yuria2]}
             - IfNil:        {extra_args:  80, tags: [yuria2]}
+            - Knapsack:     {extra_args: 12, tags: [yuria2]}
+            - VectorBenchmark: {extra_args: 3, tags: [yuria3]}
 
             - Test:     {invocations: 10, tags: [yuria ]}
             - TestGC:   {invocations: 10, extra_args: 10, tags: [yuria ]}
@@ -113,6 +115,8 @@ benchmark_suites:
             - WhileLoop:    {extra_args: 9000,   warmup:   5,   iterations:  55, tags: [yuria2]}
             - Mandelbrot:   {extra_args: 1000,   warmup:  10,   iterations: 110, tags: [yuria3]}
             - IfNil:        {extra_args: 5000,   warmup:  10,   iterations: 110, tags: [yuria3]}
+            - Knapsack:     {extra_args: 104,    warmup:  10,   iterations:  55, tags: [yuria2]}
+            - VectorBenchmark: {extra_args: 50,  warmup:  10,   iterations:  55, tags: [yuria3]}
 
     micro-somsom:
         gauge_adapter: RebenchLog


### PR DESCRIPTION
This PR updates the core-lib to the latest version, which includes a few tests and two benchmarks. The benchmarks are added to the benchmarking setup.